### PR TITLE
Support additional tags and query operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ npm run start:dev
 
 The service is exposed on port 5510, to avoid clashing with Robotoff.
 
+## Project Structure
+
+The project uses the [NestJS](https://docs.nestjs.com/) framework with [Mikro-ORM](https://mikro-orm.io/docs/installation).
+
+The entrypoint is main.js which runs database migrations and starts the service.
+
+The main business logic is in the domain/services folder and the controllers route through to here. Extensive use is made of the Mikro-ORM [EntityManager](https://mikro-orm.io/docs/entity-manager) here to interact with the database, although in some cases more raw SQL is used to optimise performance.
+
+The domain/entities folder defines the main entities and is used to automatically generate migrations using the [migration:create](https://mikro-orm.io/docs/migrations#initial-migration) npm task.
+
 ## Testing
 
 The unit tests use testcontainers to create a temporary Postgres database in Docker, which lasts for the duration of the test run. The tests share the same database while running, so ensure that tests are independant from one another by using randmoised product codes / tags.
@@ -69,7 +79,7 @@ docker-compose up -d --build
 
 The main docker-compose.yml creates the openfoodfacts-query service and associated Postres database and expects MongoDB to already exist.
 
-The dev.yml Docker Compose joins the services to the po_default network to ease communication with Product Opener and MongoDB. In staging and production comminication with MongoDB is done with an explicity network address.
+The dev.yml Docker Compose joins the services to the po_default network to ease communication with Product Opener and MongoDB. In staging and production comminication with MongoDB is done with an explicit network address.
 
 # Use
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openfoodfacts-query",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openfoodfacts-query",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@mikro-orm/core": "^5.7.13",
@@ -17,6 +17,7 @@
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
+        "@nestjs/schedule": "^4.0.0",
         "@nestjs/terminus": "^10.1.1",
         "id128": "^1.6.6",
         "mongodb": "^5.8.0",
@@ -1864,6 +1865,20 @@
         "@nestjs/core": "^9.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-4.0.0.tgz",
+      "integrity": "sha512-zz4h54m/F/1qyQKvMJCRphmuwGqJltDAkFxUXCVqJBXEs5kbPt93Pza3heCQOcMH22MZNhGlc9DmDMLXVHmgVQ==",
+      "dependencies": {
+        "cron": "3.1.3",
+        "uuid": "9.0.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.12"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-9.2.0.tgz",
@@ -2322,6 +2337,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.3.tgz",
+      "integrity": "sha512-/BJF3NT0pRMuxrenr42emRUF67sXwcZCd+S1ksG/Fcf9O7C3kKCY4uJSbKBE4KDUIYr3WMsvfmWD8hRjXExBJQ=="
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -3989,6 +4009,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cron": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.3.tgz",
+      "integrity": "sha512-KVxeKTKYj2eNzN4ElnT6nRSbjbfhyxR92O/Jdp6SH3pc05CDJws59jBrZWEMQlxevCiE6QUTrXy+Im3vC3oD3A==",
+      "dependencies": {
+        "@types/luxon": "~3.3.0",
+        "luxon": "~3.4.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -6599,6 +6628,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+      "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/macos-release": {
@@ -9333,6 +9370,18 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,15 +165,87 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.5"
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -231,12 +303,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-      "integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5",
+        "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -274,22 +346,22 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -381,9 +453,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -413,13 +485,13 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -498,9 +570,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -687,33 +759,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.7",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.7",
-        "@babel/types": "^7.22.5",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -731,13 +803,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-      "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/schedule": "^4.0.0",
     "@nestjs/terminus": "^10.1.1",
     "id128": "^1.6.6",
     "mongodb": "^5.8.0",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -9,12 +9,12 @@ export class AppController {
     private readonly queryService: QueryService,
   ) {}
 
-  @Get('importfromfile?')
+  @Get('importfromfile')
   async importFromFile(@Query('from') from = null) {
     await this.importService.importFromFile(from);
   }
 
-  @Get('importfrommongo?')
+  @Get('importfrommongo')
   async importFromMongo(
     @Query('from') from = null,
     @Query('skip') skip = null,
@@ -22,18 +22,22 @@ export class AppController {
     await this.importService.importFromMongo(from, skip);
   }
 
+  parseBoolean(value) {
+    return value == true || value?.toLowerCase() == 'true';
+  }
+
   @Post('aggregate')
-  async aggregate(@Body() body: any[]) {
-    return await this.queryService.aggregate(body);
+  async aggregate(@Body() body: any[], @Query('obsolete') obsolete) {
+    return await this.queryService.aggregate(body, this.parseBoolean(obsolete));
   }
 
   @All('count')
-  async count(@Body() body: any) {
-    return await this.queryService.count(body);
+  async count(@Body() body: any, @Query('obsolete') obsolete) {
+    return await this.queryService.count(body, this.parseBoolean(obsolete));
   }
 
   @Post('select')
-  async select(@Body() body: any) {
-    return await this.queryService.select(body);
+  async select(@Body() body: any, @Query('obsolete') obsolete) {
+    return await this.queryService.select(body, this.parseBoolean(obsolete));
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,10 +2,28 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { DomainModule } from './domain/domain.module';
 import { HealthModule } from './health/health.module';
+import { Cron, ScheduleModule } from '@nestjs/schedule';
+import { EntityManager, RequestContext } from '@mikro-orm/core';
+import { ImportService } from './domain/services/import.service';
 
 @Module({
-  imports: [DomainModule, HealthModule],
+  imports: [DomainModule, HealthModule, ScheduleModule.forRoot()],
   controllers: [AppController],
   providers: [],
 })
-export class AppModule {}
+export class AppModule {
+  constructor(
+    private readonly em: EntityManager,
+    private readonly importService: ImportService,
+  ) {}
+
+  // Refresh the PostgreSQL database from MongoDB at 2am every night
+  @Cron('00 02 * * *')
+  async refreshProducts() {
+    // The request context creates a separate entity manager instance
+    // which avoids clashes with other requests
+    await RequestContext.createAsync(this.em, async () => {
+      await this.importService.importFromMongo('');
+    });
+  }
+}

--- a/src/domain/domain.module.ts
+++ b/src/domain/domain.module.ts
@@ -2,10 +2,11 @@ import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Module } from '@nestjs/common';
 import { ImportService } from './services/import.service';
 import { QueryService } from './services/query.service';
+import { TagService } from './services/tag.service';
 
 @Module({
   imports: [MikroOrmModule.forRoot()],
-  providers: [ImportService, QueryService],
-  exports: [ImportService, QueryService],
+  providers: [ImportService, QueryService, TagService],
+  exports: [ImportService, QueryService, TagService],
 })
 export class DomainModule {}

--- a/src/domain/entities/loaded-tag.ts
+++ b/src/domain/entities/loaded-tag.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryKey } from '@mikro-orm/core';
+
+@Entity()
+export class LoadedTag {
+  @PrimaryKey()
+  id: string;
+}

--- a/src/domain/entities/product-tags.ts
+++ b/src/domain/entities/product-tags.ts
@@ -57,6 +57,20 @@ export class ProductLastEditDatesTag extends BaseProductTag {}
 export class ProductLastCheckDatesTag extends BaseProductTag {}
 @Entity()
 export class ProductTeamsTag extends BaseProductTag {}
+@Entity()
+export class ProductKeywordsTag extends BaseProductTag {}
+@Entity()
+export class ProductCodesTag extends BaseProductTag {}
+@Entity()
+export class ProductDataQualityErrorsTag extends BaseProductTag {}
+@Entity()
+export class ProductDataQualityTag extends BaseProductTag {}
+@Entity()
+export class ProductEditorsTag extends BaseProductTag {}
+@Entity()
+export class ProductStoresTag extends BaseProductTag {}
+@Entity()
+export class ProductIngredientsOriginalTag extends BaseProductTag {}
 
 /* From Config_off.pm
 # fields for drilldown facet navigation
@@ -122,4 +136,12 @@ export const MAPPED_TAGS = {
   last_edit_dates_tags: ProductLastEditDatesTag,
   last_check_dates_tags: ProductLastCheckDatesTag,
   teams_tags: ProductTeamsTag,
+  // Added later
+  _keywords: ProductKeywordsTag,
+  codes_tags: ProductCodesTag,
+  data_quality_tags: ProductDataQualityTag,
+  data_quality_errors_tags: ProductDataQualityErrorsTag,
+  editors_tags: ProductEditorsTag,
+  stores_tags: ProductStoresTag,
+  ingredients_original_tags: ProductIngredientsOriginalTag,
 };

--- a/src/domain/services/import.service.spec.ts
+++ b/src/domain/services/import.service.spec.ts
@@ -6,7 +6,23 @@ import { ProductIngredientsTag } from '../entities/product-tags';
 import { createTestingModule, randomCode } from '../../../test/test.helper';
 
 let index = 0;
-const productId = randomCode();
+const productIdNew = randomCode();
+const productIdExisting = randomCode();
+const products = [
+  {
+    // This one will be new
+    code: productIdNew,
+    last_modified_t: 1692032161,
+    ingredients_tags: ['test'],
+  },
+  {
+    // This one will already exist
+    code: productIdExisting,
+    last_modified_t: 1692032161,
+    ingredients_tags: ['new_ingredient', 'old_ingredient'],
+  },
+];
+
 jest.mock('mongodb', () => {
   return {
     MongoClient: jest.fn(() => ({
@@ -15,13 +31,7 @@ jest.mock('mongodb', () => {
         collection: () => ({
           find: () => ({
             next: async () => {
-              return index++ < 1
-                ? {
-                    code: productId,
-                    last_modified_t: 1692032161,
-                    ingredients_tags: ['test'],
-                  }
-                : null;
+              return index++ <= products.length ? products[index - 1] : null;
             },
             close: jest.fn(),
           }),
@@ -33,20 +43,54 @@ jest.mock('mongodb', () => {
 });
 
 describe('importFromMongo', () => {
-  it('should import a new product', async () => {
+  it('should import a new product update existing products and not delete existing products', async () => {
     await createTestingModule([DomainModule], async (app) => {
       const importService = app.get(ImportService);
       importService.deleteAllProducts = jest.fn();
+
+      // GIVEN: Two existing products, one of which is in Mongo plus one new one in Mongo
+      const em = app.get(EntityManager);
+      const productExisting = em.create(Product, { code: productIdExisting });
+      em.create(ProductIngredientsTag, {
+        product: productExisting,
+        value: 'old_ingredient',
+      });
+
+      const productIdUnchanged = randomCode();
+      const productUnchanged = em.create(Product, { code: productIdUnchanged });
+      em.create(ProductIngredientsTag, {
+        product: productUnchanged,
+        value: 'unchanged_ingredient',
+      });
+
+      // WHEN:Doing a full import from MongoDB
       await importService.importFromMongo();
 
-      expect(importService.deleteAllProducts).toHaveBeenCalled();
-      const em = app.get(EntityManager);
-      const product = await em.findOne(Product, { code: productId });
-      expect(product).toBeTruthy();
-      const ingredients = await em.findOne(ProductIngredientsTag, {
-        product: product,
+      expect(importService.deleteAllProducts).not.toHaveBeenCalled();
+      const productNew = await em.findOne(Product, { code: productIdNew });
+      expect(productNew).toBeTruthy();
+      const ingredientsNew = await em.find(ProductIngredientsTag, {
+        product: productNew,
       });
-      expect(ingredients).toBeTruthy();
+      expect(ingredientsNew).toHaveLength(1);
+      expect(ingredientsNew[0].value).toBe('test');
+
+      const ingredientsExisting = await em.find(ProductIngredientsTag, {
+        product: productExisting,
+      });
+      expect(ingredientsExisting).toHaveLength(2);
+      expect(
+        ingredientsExisting.find((i) => i.value === 'old_ingredient'),
+      ).toBeTruthy();
+      expect(
+        ingredientsExisting.find((i) => i.value === 'new_ingredient'),
+      ).toBeTruthy();
+
+      const ingredientsUnchanged = await em.find(ProductIngredientsTag, {
+        product: productUnchanged,
+      });
+      expect(ingredientsUnchanged).toHaveLength(1);
+      expect(ingredientsUnchanged[0].value).toBe('unchanged_ingredient');
     });
   });
 });

--- a/src/domain/services/import.service.spec.ts
+++ b/src/domain/services/import.service.spec.ts
@@ -66,6 +66,7 @@ describe('importFromMongo', () => {
       // WHEN:Doing a full import from MongoDB
       await importService.importFromMongo();
 
+      // THEN: New product is addeded, updated product is updated and other product is unchanged
       expect(importService.deleteAllProducts).not.toHaveBeenCalled();
       const productNew = await em.findOne(Product, { code: productIdNew });
       expect(productNew).toBeTruthy();

--- a/src/domain/services/import.service.ts
+++ b/src/domain/services/import.service.ts
@@ -33,7 +33,6 @@ export class ImportService {
       filter['last_modified_t'] = { $gt: fromTime };
     }
     const updateId = Ulid.generate().toRaw();
-    if (!from) await this.deleteAllProducts();
 
     this.logger.log('Connecting to MongoDB');
     const client = new MongoClient(process.env.MONGO_URI);
@@ -57,7 +56,7 @@ export class ImportService {
 
         i++;
         if (skip && i < skip) continue;
-        await this.fixupProduct(!!from, updateId, data, obsolete);
+        await this.fixupProduct(true, updateId, data, obsolete);
         if (!(i % this.importBatchSize)) {
           await this.em.flush();
           this.em.clear();
@@ -66,12 +65,11 @@ export class ImportService {
           this.logger.log(`Updated ${i}`);
         }
       }
-      //await this.em.getConnection().execute('commit');
       await this.em.flush();
       this.logger.log(`${i}${obsolete ? ' Obsolete' : ''} Products imported`);
       await cursor.close();
     }
-    await this.updateTags(!!from, updateId);
+    await this.updateTags(true, updateId);
     await client.close();
     this.logger.log('Finished');
   }

--- a/src/domain/services/import.service.ts
+++ b/src/domain/services/import.service.ts
@@ -23,7 +23,11 @@ export class ImportService {
 
   private tags = Object.keys(MAPPED_TAGS);
 
+  /** Import Products from MongoDB */
   async importFromMongo(from?: string, skip?: number) {
+    // If the from parameter is supplied but it is empty then obtain the most
+    // recent modified time from the database and query MongoDB for products
+    // modified since then
     if (!from && from != null) {
       const result = await this.em
         .createQueryBuilder(Product, 'p')
@@ -36,12 +40,17 @@ export class ImportService {
       const fromTime = Math.floor(new Date(from).getTime() / 1000);
       filter['last_modified_t'] = { $gt: fromTime };
     }
+
+    // The update id is unique to this run and is used later to run other
+    // queries that should only affect products loaded in this import
     const updateId = Ulid.generate().toRaw();
 
     this.logger.log('Connecting to MongoDB');
     const client = new MongoClient(process.env.MONGO_URI);
     await client.connect();
     const db = client.db('off');
+
+    // Only fetch the tags that we store to limit the payload from MongoDB
     const projection = {};
     for (const key of MAPPED_FIELDS) {
       projection[key] = 1;
@@ -49,7 +58,10 @@ export class ImportService {
     for (const key of this.tags) {
       projection[key] = 1;
     }
+
     this.logger.log('Starting import' + (from ? ' from ' + from : ''));
+    // Repeat the below for normal and then obsolete products
+    // Both are stored in the same table in PostgreSQL
     for (const obsolete of [false, true]) {
       const products = db.collection(`products${obsolete ? '_obsolete' : ''}`);
       const cursor = products.find(filter, { projection });
@@ -60,8 +72,11 @@ export class ImportService {
 
         i++;
         if (skip && i < skip) continue;
+        // Find the product if it exists and populate the standard fields
         await this.fixupProduct(true, updateId, data, obsolete);
         if (!(i % this.importBatchSize)) {
+          // This will cause a commit and then clear the Mikro-ORM cache
+          // to minimise memory consumption for large imports
           await this.em.flush();
           this.em.clear();
         }
@@ -73,11 +88,13 @@ export class ImportService {
       this.logger.log(`${i}${obsolete ? ' Obsolete' : ''} Products imported`);
       await cursor.close();
     }
+    // Tags are popualted using raw SQL from the data field
     await this.updateTags(!!from, updateId);
     await client.close();
     this.logger.log('Finished');
   }
 
+  /** Populate a Product record from MongoDB document */
   async fixupProduct(
     update: boolean,
     updateId: string,
@@ -104,6 +121,7 @@ export class ImportService {
     product.lastUpdateId = updateId;
   }
 
+  /** Find an existing document by product code, or create a new one */
   private async findOrNewProduct(update: boolean, data: any) {
     let product: Product;
     if (update) {
@@ -117,11 +135,19 @@ export class ImportService {
     return product;
   }
 
+  /**
+   * Products are first loaded with the tags in the data JSONB property.
+   * SQL is then run to insert this into the individual tag tables.
+   * This was found to be quicker than using ORM functionality
+   */
   private async updateTags(update: boolean, updateId: string) {
     const connection = this.em.getConnection();
     for (const [tag, entity] of Object.entries(MAPPED_TAGS)) {
       let logText = `Updated ${tag}`;
+      // Get the underlying table name for the entity
       const tableName = this.em.getMetadata(entity).tableName;
+
+      // Delete existing tags for products that were imorted on this run
       const deleted = await connection.execute(
         `delete from ${tableName} 
       where product_id in (select id from product 
@@ -130,6 +156,8 @@ export class ImportService {
         'run',
       );
       logText += ` deleted ${deleted['affectedRows']},`;
+
+      // Add tags back in with the updated information
       const results = await connection.execute(
         `insert into ${tableName} (product_id, value, obsolete)
         select DISTINCT id, tag.value, obsolete from product 
@@ -138,7 +166,11 @@ export class ImportService {
         [updateId],
         'run',
       );
+
+      // Commit after each tag to minimise server snapshot size
       await connection.execute('commit');
+
+      // If this is a full load we can flag the tag as now available for query
       if (!update) {
         await this.tagService.tagLoaded(tag);
         this.em.flush();
@@ -154,6 +186,10 @@ export class ImportService {
     await this.em.execute('truncate table product cascade');
   }
 
+  /**
+   * Imports from a openfoodfacts-products.jsonl uploaded to the data folder
+   * Mainly used for testing and may be removed.
+   */
   async importFromFile(from = null) {
     const updateId = Ulid.generate().toRaw();
     const fromTime = from ? Math.floor(new Date(from).getTime() / 1000) : null;

--- a/src/domain/services/query.service.spec.ts
+++ b/src/domain/services/query.service.spec.ts
@@ -120,10 +120,12 @@ describe('count', () => {
     await createTestingModule([DomainModule], async (app) => {
       const { originValue } = await createTestTags(app);
       const queryService = app.get(QueryService);
-      const response = await queryService.count({
-        obsolete: 1,
-        origins_tags: originValue,
-      });
+      const response = await queryService.count(
+        {
+          origins_tags: originValue,
+        },
+        true,
+      );
       expect(response).toBe(1);
     });
   });
@@ -132,10 +134,12 @@ describe('count', () => {
     await createTestingModule([DomainModule], async (app) => {
       const { originValue } = await createTestTags(app);
       const queryService = app.get(QueryService);
-      const response = await queryService.count({
-        obsolete: 0,
-        origins_tags: originValue,
-      });
+      const response = await queryService.count(
+        {
+          origins_tags: originValue,
+        },
+        false,
+      );
       expect(response).toBe(3);
     });
   });
@@ -278,10 +282,10 @@ describe('aggregate', () => {
     await createTestingModule([DomainModule], async (app) => {
       const { originValue } = await createTestTags(app);
       const queryService = app.get(QueryService);
-      const response = await queryService.aggregate([
-        { $match: { obsolete: true } },
-        { $group: { _id: '$origins_tags' } },
-      ]);
+      const response = await queryService.aggregate(
+        [{ $match: {} }, { $group: { _id: '$origins_tags' } }],
+        true,
+      );
       const myTag = response.find((r) => r._id === originValue);
       expect(myTag).toBeTruthy();
       expect(parseInt(myTag.count)).toBe(1);
@@ -307,10 +311,12 @@ describe('select', () => {
     await createTestingModule([DomainModule], async (app) => {
       const { aminoValue, product4 } = await createTestTags(app);
       const queryService = app.get(QueryService);
-      const response = await queryService.select({
-        amino_acids_tags: aminoValue,
-        obsolete: 'true',
-      });
+      const response = await queryService.select(
+        {
+          amino_acids_tags: aminoValue,
+        },
+        true,
+      );
       expect(response).toHaveLength(1);
       const p4 = response.find((r) => r.code === product4.code);
       expect(p4).toBeTruthy();

--- a/src/domain/services/query.service.spec.ts
+++ b/src/domain/services/query.service.spec.ts
@@ -11,6 +11,7 @@ import {
 import { QueryService } from './query.service';
 import { createTestingModule, randomCode } from '../../../test/test.helper';
 import { UnprocessableEntityException } from '@nestjs/common';
+import { LoadedTag } from '../entities/loaded-tag';
 
 describe('count', () => {
   it('should count the number of products with a tag', async () => {
@@ -76,6 +77,21 @@ describe('count', () => {
       }
     });
   });
+
+  it('should throw and unprocessable exception for a tag that hasnt been loaded', async () => {
+    await createTestingModule([DomainModule], async (app) => {
+      try {
+        const em = app.get(EntityManager);
+        await em.nativeDelete(LoadedTag, { id: 'ingredients_tags' });
+        await em.flush();
+        await app.get(QueryService).count({ ingredients_tags: 'x' });
+        fail('should not get here');
+      } catch (e) {
+        expect(e).toBeInstanceOf(UnprocessableEntityException);
+      }
+    });
+  });
+
   it('should cope with more than two filters', async () => {
     await createTestingModule([DomainModule], async (app) => {
       const { originValue, aminoValue, neucleotideValue } =

--- a/src/domain/services/query.service.spec.ts
+++ b/src/domain/services/query.service.spec.ts
@@ -150,6 +150,20 @@ describe('count', () => {
       expect(response).toBe(1);
     });
   });
+
+  it('should cope with a $and filter', async () => {
+    await createTestingModule([DomainModule], async (app) => {
+      const { aminoValue, aminoValue2 } = await createTestTags(app);
+      const queryService = app.get(QueryService);
+      const response = await queryService.count({
+        $and: [
+          { amino_acids_tags: aminoValue },
+          { amino_acids_tags: aminoValue2 },
+        ],
+      });
+      expect(response).toBe(1);
+    });
+  });
 });
 
 describe('aggregate', () => {

--- a/src/domain/services/query.service.spec.ts
+++ b/src/domain/services/query.service.spec.ts
@@ -283,16 +283,22 @@ async function createTestTags(app) {
   const aminoValue = randomCode();
   const neucleotideValue = randomCode();
   const creatorValue = randomCode();
-  
+
   // Create some dummy products with a specific tag
   const product1 = em.create(Product, { code: randomCode() });
-  const product2 = em.create(Product, { code: randomCode(), creator: creatorValue });
-  const product3 = em.create(Product, { code: randomCode(), creator: creatorValue });
+  const product2 = em.create(Product, {
+    code: randomCode(),
+    creator: creatorValue,
+  });
+  const product3 = em.create(Product, {
+    code: randomCode(),
+    creator: creatorValue,
+  });
   const product4 = em.create(Product, { code: randomCode(), obsolete: true });
 
   // Matrix for testing
   // Product  | Origin | AminoAcid | Neucleotide | Obsolete | Creator
-  // Product1 |   x    |     x     |      x      |          |    
+  // Product1 |   x    |     x     |      x      |          |
   // Product2 |   x    |     x     |             |          |    x
   // Product3 |   x    |           |      x      |          |    x
   // Product4 |   x    |     x     |      x      |    x     |

--- a/src/domain/services/query.service.ts
+++ b/src/domain/services/query.service.ts
@@ -64,7 +64,6 @@ export class QueryService {
   }
 
   private addMatches(match: any, qb: QueryBuilder<object>, parentEntity) {
-    const parentId = parentEntity === Product ? 'id': 'product_id';
     const whereLog = [];
     for (const [matchTag, matchValue] of Object.entries(match)) {
       let whereValue = matchValue;
@@ -77,9 +76,12 @@ export class QueryService {
       const qbWhere = this.em
         .createQueryBuilder(matchEntity, 'pt2')
         .select('*')
-        .where(`pt2.${this.productId(matchEntity)} = pt.${this.productId(parentEntity)} and pt2.${matchColumn} = ?`, [
-          whereValue,
-        ]);
+        .where(
+          `pt2.${this.productId(matchEntity)} = pt.${this.productId(
+            parentEntity,
+          )} and pt2.${matchColumn} = ?`,
+          [whereValue],
+        );
       qb.andWhere(`${not ? 'NOT ' : ''}EXISTS (${qbWhere.getKnexQuery()})`);
       whereLog.push(`${matchTag} ${not ? '!=' : '=='} ${whereValue}`);
     }
@@ -87,7 +89,7 @@ export class QueryService {
   }
 
   productId(entity) {
-    return entity === Product ? 'id': 'product_id';
+    return entity === Product ? 'id' : 'product_id';
   }
 
   obsoleteWhere(body: any) {
@@ -108,7 +110,7 @@ export class QueryService {
     qb.select(`count(*) count`);
     qb.where(obsoleteWhere);
 
-    let whereLog = [];
+    const whereLog = [];
     if (tag) {
       let matchValue = body[tag];
       const not = matchValue?.['$ne'];
@@ -125,7 +127,9 @@ export class QueryService {
     const results = await qb.execute();
     const response = results[0].count;
     this.logger.log(
-      `Processed ${whereLog.join(' and ')} in ${Date.now() - start} ms. Count: ${response}`,
+      `Processed ${whereLog.join(' and ')} in ${
+        Date.now() - start
+      } ms. Count: ${response}`,
     );
     return parseInt(response);
   }
@@ -135,7 +139,7 @@ export class QueryService {
     this.logger.debug(body);
 
     const obsoleteWhere = this.obsoleteWhere(body);
-    let entity: EntityName<object> = Product;
+    const entity: EntityName<object> = Product;
     const qb = this.em.createQueryBuilder(entity, 'pt');
     qb.select(`*`);
     qb.where(obsoleteWhere);
@@ -145,7 +149,9 @@ export class QueryService {
     this.logger.debug(qb.getFormattedQuery());
     const results = await qb.execute();
     this.logger.log(
-      `Processed ${whereLog.join(' and ')} in ${Date.now() - start} ms. Selected ${results.length} records`,
+      `Processed ${whereLog.join(' and ')} in ${
+        Date.now() - start
+      } ms. Selected ${results.length} records`,
     );
     return results;
   }

--- a/src/domain/services/query.service.ts
+++ b/src/domain/services/query.service.ts
@@ -17,19 +17,28 @@ export class QueryService {
     private readonly tagService: TagService,
   ) {}
 
+  /** Uses the MongoDB aggregate pipeline style query to return counts grouped by a specified facet */
   async aggregate(body: any[], obsolete = false) {
     const start = Date.now();
     this.logger.debug(body);
 
+    // Match includes any filter criteria
     const match = body.find((o: any) => o['$match'])?.['$match'];
+
+    // Group indicates what field to group results by
     const group = body.find((o: any) => o['$group'])?.['$group'];
+
+    // If count is specified then this just counts the number of distinct facet values
     const count = body.some((o: any) => o['$count']);
+
+    // Limit and skip support paging of large results (like ingredients)
     const limit = body.find((o: any) => o['$limit'])?.['$limit'];
     const skip = body.find((o: any) => o['$skip'])?.['$skip'];
 
     let tag = group['_id'].substring(1);
     if (tag === 'users_tags') tag = 'creator';
 
+    // Determine which entity to query (Product or a specific Tag table)
     const { entity, column } = await this.getEntityAndColumn(tag);
     let qb = this.em.createQueryBuilder(entity, 'pt');
     if (!count) {
@@ -37,8 +46,10 @@ export class QueryService {
     } else {
       qb.select(`${column}`).distinct();
     }
+    // Add the where clause that determines whether to fetch obsolete products or not
     qb.where(this.obsoleteWhere(obsolete));
 
+    // Add filter criteria to the where clause
     const whereLog = await this.addMatches(this.parseFilter(match), qb, entity);
 
     if (count) {
@@ -52,7 +63,6 @@ export class QueryService {
 
     this.logger.debug(qb.getFormattedQuery());
     const results = await qb.execute();
-    //this.logger.log(results);
     this.logger.debug(
       `Processed ${tag}${
         whereLog.length ? ` where ${whereLog.join(' and ')}` : ''
@@ -67,16 +77,29 @@ export class QueryService {
     return results;
   }
 
+  /**
+   * Turns the filter into a simple list of tags and values that can be "anded" together
+   * note this doesn't currently support "or" operations
+   */
   private parseFilter(matches): [string, any][] {
     const filters = [];
     for (const filter of Object.entries(matches)) {
       if (filter[0] === '$and') {
+        // If the key is $and then the value will be an array of objects, e.g.
+        // $and: [
+        //   { amino_acids_tags: "value1" },
+        //   { amino_acids_tags: "value2" },
+        // ]
+        // Expand these to just appear as additional filter entries
         for (const subFilter of filter[1] as []) {
           filters.push(...this.parseFilter(subFilter));
         }
       } else {
         const all = filter[1]['$all'];
         if (all) {
+          // All is very similar to $and except that it is specified for the values, e.g.
+          // amino_acids_tags: { $all: ["value1", "value1"] }
+          // Simply append these as multiple tag / value pairs for the same tag
           for (const value of all) {
             filters.push([filter[0], value]);
           }
@@ -88,6 +111,13 @@ export class QueryService {
     return filters;
   }
 
+  /**
+   * Iterates over the list of tag / value pairs and adds them as where clauses to the supplied QueryBuilder.
+   * @param filters The list of tag / value pairs
+   * @param qb The QueryBuilder to add the where clause to
+   * @param parentEntity Determines the column in which the product id is found in the perant
+   * @returns A human-readable summary of the clauses added
+   */
   private async addMatches(
     filters: [string, any][],
     qb: QueryBuilder<object>,
@@ -96,12 +126,15 @@ export class QueryService {
     const whereLog = [];
     for (const [matchTag, matchValue] of filters) {
       let whereValue = matchValue;
+      // If $ne is specified then a not equal query is needed, e.g.
+      // additives_tags: { $ne: "value1" }
       const not = matchValue?.['$ne'];
       if (not) {
         whereValue = not;
       }
       const { entity: matchEntity, column: matchColumn } =
         await this.getEntityAndColumn(matchTag);
+      // The following creates an EXISTS / NOT EXISTS sub-query for the specified tag
       const qbWhere = this.em
         .createQueryBuilder(matchEntity, 'pt2')
         .select('*')
@@ -117,25 +150,29 @@ export class QueryService {
     return whereLog;
   }
 
+  /** Determins the name of the product id field */
   productId(entity) {
     return entity === Product ? 'id' : 'product_id';
   }
 
+  /** Returns a where expression for the onsolete flag */
   obsoleteWhere(obsolete: boolean) {
     return `${obsolete ? '' : 'not '}pt.obsolete`;
   }
 
+  /** Counts the number of document meeting the specified criteria */
   async count(body: any, obsolete = false) {
     const start = Date.now();
     this.logger.debug(body);
 
-    const obsoleteWhere = this.obsoleteWhere(obsolete);
     const filters = this.parseFilter(body ?? {});
+
+    // The main table for the query is determined from the first filter
     const mainFilter = filters.shift();
     const { entity, column } = await this.getEntityAndColumn(mainFilter?.[0]);
     const qb = this.em.createQueryBuilder(entity, 'pt');
     qb.select(`count(*) count`);
-    qb.where(obsoleteWhere);
+    qb.where(this.obsoleteWhere(obsolete));
 
     const whereLog = [];
     if (mainFilter) {
@@ -146,6 +183,8 @@ export class QueryService {
       }
       whereLog.push(`${mainFilter[0]} ${not ? '!=' : '=='} ${matchValue}`);
       qb.andWhere(`${not ? 'NOT ' : ''}pt.${column} = ?`, [matchValue]);
+
+      // Add any further where clauses
       whereLog.push(...(await this.addMatches(filters, qb, entity)));
     }
 
@@ -160,15 +199,15 @@ export class QueryService {
     return parseInt(response);
   }
 
+  /** Fetches the entire document record for the filter. Not used by Product Opener */
   async select(body: any, obsolete = false) {
     const start = Date.now();
     this.logger.debug(body);
 
-    const obsoleteWhere = this.obsoleteWhere(obsolete);
     const entity: EntityName<object> = Product;
     const qb = this.em.createQueryBuilder(entity, 'pt');
     qb.select(`*`);
-    qb.where(obsoleteWhere);
+    qb.where(this.obsoleteWhere(obsolete));
 
     const whereLog = await this.addMatches(this.parseFilter(body), qb, entity);
 
@@ -182,15 +221,20 @@ export class QueryService {
     return results;
   }
 
+  /** Determines the entity to use for the query. */
   private async getEntityAndColumn(tag: any) {
     let entity: EntityName<object>;
     let column = 'value';
     if (!tag || MAPPED_FIELDS.includes(tag)) {
+      // The field is a signle value stored on the Product itself
       entity = Product;
       column = tag;
     } else {
       entity = MAPPED_TAGS[tag];
       if (entity) {
+        // Check to see if the tag has been loaded. This allows us to introduce
+        // new tags but they will initially not be supported until a full import
+        // is performed
         if (!(await this.tagService.getLoadedTags()).includes(tag)) {
           const message = `Tag '${tag}' is not loaded`;
           this.logger.warn(message);

--- a/src/domain/services/query.service.ts
+++ b/src/domain/services/query.service.ts
@@ -76,7 +76,14 @@ export class QueryService {
           filters.push(...this.parseFilter(subFilter));
         }
       } else {
-        filters.push(filter);
+        const all = filter[1]['$all'];
+        if (all) {
+          for (const value of all) {
+            filters.push([filter[0], value]);
+          }
+        } else {
+          filters.push(filter);
+        }
       }
     }
     return filters;

--- a/src/domain/services/tag.service.ts
+++ b/src/domain/services/tag.service.ts
@@ -1,0 +1,25 @@
+import { EntityManager } from '@mikro-orm/core';
+import { Injectable } from '@nestjs/common';
+import { LoadedTag } from '../entities/loaded-tag';
+
+@Injectable()
+export class TagService {
+  loadedTags = [];
+  tagsLoaded = false;
+  constructor(private readonly em: EntityManager) {}
+
+  async getLoadedTags() {
+    if (!this.tagsLoaded) {
+      const loadedTags = await this.em.find(LoadedTag, {});
+      this.loadedTags = loadedTags.map((t) => t.id);
+      this.tagsLoaded = true;
+    }
+    return this.loadedTags;
+  }
+
+  async tagLoaded(tag: string) {
+    if ((await this.getLoadedTags()).includes(tag)) return;
+    this.loadedTags.push(tag);
+    this.em.create(LoadedTag, { id: tag });
+  }
+}

--- a/src/domain/services/tag.service.ts
+++ b/src/domain/services/tag.service.ts
@@ -21,5 +21,6 @@ export class TagService {
     if ((await this.getLoadedTags()).includes(tag)) return;
     this.loadedTags.push(tag);
     this.em.create(LoadedTag, { id: tag });
+    await this.em.flush();
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,12 @@ import { MikroORM } from '@mikro-orm/core';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Run migrations if needed. Note may need to change this if multiple containers are used for scaling
   const migrator = app.get(MikroORM).getMigrator();
   await migrator.up();
+
+  // Start the service. IP 0.0.0.0 ensure it is available to Docker
   await app.listen(5510, '0.0.0.0');
 }
 bootstrap();

--- a/src/migrations/.snapshot-query.json
+++ b/src/migrations/.snapshot-query.json
@@ -538,6 +538,77 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_codes_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_codes_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_codes_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_codes_tag_product_id_foreign": {
+          "constraintName": "product_codes_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_codes_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_countries_tag",
       "schema": "query",
       "indexes": [
@@ -569,6 +640,148 @@
             "product_id"
           ],
           "localTableName": "query.product_countries_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_data_quality_errors_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_data_quality_errors_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_data_quality_errors_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_data_quality_errors_tag_product_id_foreign": {
+          "constraintName": "product_data_quality_errors_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_data_quality_errors_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_data_quality_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_data_quality_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_data_quality_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_data_quality_tag_product_id_foreign": {
+          "constraintName": "product_data_quality_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_data_quality_tag",
           "referencedColumnNames": [
             "id"
           ],
@@ -751,6 +964,77 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_editors_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_editors_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_editors_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_editors_tag_product_id_foreign": {
+          "constraintName": "product_editors_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_editors_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_emb_codes_tag",
       "schema": "query",
       "indexes": [
@@ -893,6 +1177,77 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_ingredients_original_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_ingredients_original_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_ingredients_original_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_ingredients_original_tag_product_id_foreign": {
+          "constraintName": "product_ingredients_original_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_ingredients_original_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_ingredients_tag",
       "schema": "query",
       "indexes": [
@@ -924,6 +1279,77 @@
             "product_id"
           ],
           "localTableName": "query.product_ingredients_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_keywords_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_keywords_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_keywords_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_keywords_tag_product_id_foreign": {
+          "constraintName": "product_keywords_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_keywords_tag",
           "referencedColumnNames": [
             "id"
           ],
@@ -1918,6 +2344,77 @@
             "product_id"
           ],
           "localTableName": "query.product_states_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_stores_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_stores_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_stores_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_stores_tag_product_id_foreign": {
+          "constraintName": "product_stores_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_stores_tag",
           "referencedColumnNames": [
             "id"
           ],

--- a/src/migrations/.snapshot-query.json
+++ b/src/migrations/.snapshot-query.json
@@ -8,6 +8,34 @@
       "columns": {
         "id": {
           "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        }
+      },
+      "name": "loaded_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "keyName": "loaded_tag_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
           "type": "uuid",
           "unsigned": false,
           "autoincrement": false,

--- a/src/migrations/Migration20231030101011.ts
+++ b/src/migrations/Migration20231030101011.ts
@@ -5,6 +5,9 @@ export class Migration20231030101011 extends Migration {
     this.addSql(
       'create table "query"."loaded_tag" ("id" text not null, constraint "loaded_tag_pkey" primary key ("id"));',
     );
+    this.addSql(
+      `insert into "query"."loaded_tag" ("id") values ('countries_tags'),('nutrition_grades_tags'),('nova_groups_tags'),('ecoscore_tags'),('brands_tags'),('categories_tags'),('labels_tags'),('packaging_tags'),('origins_tags'),('manufacturing_places_tags'),('emb_codes_tags'),('ingredients_tags'),('additives_tags'),('vitamins_tags'),('minerals_tags'),('amino_acids_tags'),('nucleotides_tags'),('other_nutritional_substances_tags'),('allergens_tags'),('traces_tags'),('misc_tags'),('languages_tags'),('states_tags'),('data_sources_tags'),('entry_dates_tags'),('last_edit_dates_tags'),('last_check_dates_tags'),('teams_tags') on conflict do nothing;`,
+    );
   }
 
   async down(): Promise<void> {

--- a/src/migrations/Migration20231030101011.ts
+++ b/src/migrations/Migration20231030101011.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231030101011 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "query"."loaded_tag" ("id" text not null, constraint "loaded_tag_pkey" primary key ("id"));',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql('drop table if exists "query"."loaded_tag" cascade;');
+  }
+}

--- a/src/migrations/Migration20231030115649.ts
+++ b/src/migrations/Migration20231030115649.ts
@@ -1,0 +1,104 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231030115649 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "query"."product_codes_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_codes_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_codes_tag_value_index" on "query"."product_codes_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_data_quality_errors_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_data_quality_errors_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_data_quality_errors_tag_value_index" on "query"."product_data_quality_errors_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_data_quality_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_data_quality_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_data_quality_tag_value_index" on "query"."product_data_quality_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_editors_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_editors_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_editors_tag_value_index" on "query"."product_editors_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_ingredients_original_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_ingredients_original_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_ingredients_original_tag_value_index" on "query"."product_ingredients_original_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_keywords_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_keywords_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_keywords_tag_value_index" on "query"."product_keywords_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_stores_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_stores_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_stores_tag_value_index" on "query"."product_stores_tag" ("value");',
+    );
+
+    this.addSql(
+      'alter table "query"."product_codes_tag" add constraint "product_codes_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_data_quality_errors_tag" add constraint "product_data_quality_errors_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_data_quality_tag" add constraint "product_data_quality_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_editors_tag" add constraint "product_editors_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_ingredients_original_tag" add constraint "product_ingredients_original_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_keywords_tag" add constraint "product_keywords_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_stores_tag" add constraint "product_stores_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql('drop table if exists "query"."product_codes_tag" cascade;');
+
+    this.addSql(
+      'drop table if exists "query"."product_data_quality_errors_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_data_quality_tag" cascade;',
+    );
+
+    this.addSql('drop table if exists "query"."product_editors_tag" cascade;');
+
+    this.addSql(
+      'drop table if exists "query"."product_ingredients_original_tag" cascade;',
+    );
+
+    this.addSql('drop table if exists "query"."product_keywords_tag" cascade;');
+
+    this.addSql('drop table if exists "query"."product_stores_tag" cascade;');
+  }
+}

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -47,4 +47,6 @@ export default defineConfig({
     path: 'dist/migrations',
     pathTs: 'src/migrations',
   },
+  // Uncomment the below and 'app.useLogger(new Logger());' to the test to see Mikro-ORM logs
+  // debug: ['query', 'query-params'],
 });


### PR DESCRIPTION
Adding support for a number of additional tags. To support this had to update the import code to only set a tag as queryable when a ful import had been performed.

Updated the full import code not delete existing products so it does not break the existing service.

Also added support for $and and $all operators as these are commonly used