### PR TITLE
Support for Ingredients and Redis

### DIFF
--- a/.env
+++ b/.env
@@ -9,4 +9,4 @@ POSTGRES_DB=query
 POSTGRES_USER=productopener
 POSTGRES_PASSWORD=productopener
 MONGO_URI=mongodb://localhost:27017
-REDIS_URL=redis://localhost:6379
+#REDIS_URL=redis://localhost:6379

--- a/.env
+++ b/.env
@@ -9,3 +9,4 @@ POSTGRES_DB=query
 POSTGRES_USER=productopener
 POSTGRES_PASSWORD=productopener
 MONGO_URI=mongodb://localhost:27017
+REDIS_URL=redis://localhost:6379

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nestjs/terminus": "^10.1.1",
         "id128": "^1.6.6",
         "mongodb": "^5.8.0",
+        "redis": "^4.6.11",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.2.0"
       },
@@ -2111,6 +2112,64 @@
         "npm": ">=5.0.0"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.12.tgz",
+      "integrity": "sha512-/ZjE18HRzMd80eXIIUIPcH81UoZpwulbo8FmbElrjPqH0QC0SeIKu1BOU49bO5trM5g895kAjhvalt5h77q+4A==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.6.tgz",
+      "integrity": "sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.6.tgz",
+      "integrity": "sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.5.tgz",
+      "integrity": "sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@rushstack/ts-command-line": {
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.15.1.tgz",
@@ -3815,6 +3874,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5218,6 +5285,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -7964,6 +8039,19 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.11.tgz",
+      "integrity": "sha512-kg1Lt4NZLYkAjPOj/WcyIGWfZfnyfKo1Wg9YKVSlzhFwxpFIl3LYI8BWy1Ab963LLDsTz2+OwdsesHKljB3WMQ==",
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.12",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.6",
+        "@redis/search": "1.1.6",
+        "@redis/time-series": "1.0.5"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/platform-express": "^9.0.0",
         "@nestjs/schedule": "^4.0.0",
         "@nestjs/terminus": "^10.1.1",
+        "fast-deep-equal": "^3.1.3",
         "id128": "^1.6.6",
         "mongodb": "^5.8.0",
         "redis": "^4.6.11",
@@ -4940,8 +4941,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "prettier": "^2.3.2",
         "source-map-support": "^0.5.20",
         "supertest": "^6.1.3",
+        "testcontainers": "^10.4.0",
         "ts-jest": "29.1.0",
         "ts-loader": "^9.2.3",
         "ts-node": "^10.0.0",
@@ -2364,6 +2365,26 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
+    },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "3.3.23",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.23.tgz",
+      "integrity": "sha512-Lz5J+NFgZS4cEVhquwjIGH4oQwlVn2h7LXD3boitujBnzOE5o7s9H8hchEjoDK2SlRsJTogdKnQeiJgPPKLIEw==",
+      "dev": true,
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "8.44.0",
@@ -7162,9 +7183,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -9005,22 +9026,23 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.2.1.tgz",
-      "integrity": "sha512-R9LUMUEkKGSL2M4cP466Jah+Vi+ZLFlvrT4BENjEKJKNzubATOmDk26RHe8DHeFT+hnMD6fvVii+McXr0UTO7g==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.4.0.tgz",
+      "integrity": "sha512-kMmJXOAuJeQTRbGSrIEBaAzTzGzmY4+DU5xW5CxgzxgywCoy53ubeiTh3eZ1rzT54YR3zf0nijlb/l7OT4E+/g==",
       "dev": true,
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "archiver": "^5.3.1",
+        "@types/dockerode": "^3.3.21",
+        "archiver": "^5.3.2",
         "async-lock": "^1.4.0",
         "byline": "^5.0.0",
         "debug": "^4.3.4",
         "docker-compose": "^0.24.2",
         "dockerode": "^3.3.5",
         "get-port": "^5.1.1",
-        "node-fetch": "^2.6.12",
+        "node-fetch": "^2.7.0",
         "proper-lockfile": "^4.1.2",
-        "properties-reader": "^2.2.0",
+        "properties-reader": "^2.3.0",
         "ssh-remote-port-forward": "^1.0.4",
         "tar-fs": "^3.0.4",
         "tmp": "^0.2.1"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "prettier": "^2.3.2",
     "source-map-support": "^0.5.20",
     "supertest": "^6.1.3",
+    "testcontainers": "^10.4.0",
     "ts-jest": "29.1.0",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "import": "nest build && node dist/import",
     "migration:create": "nest build && mikro-orm migration:create",
-    "migration:up": "nest build && mikro-orm migration:up"
+    "migration:up": "nest build && mikro-orm migration:up",
+    "migration:down": "nest build && mikro-orm migration:down"
   },
   "dependencies": {
     "@mikro-orm/core": "^5.7.13",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/terminus": "^10.1.1",
     "id128": "^1.6.6",
     "mongodb": "^5.8.0",
+    "redis": "^4.6.11",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/schedule": "^4.0.0",
     "@nestjs/terminus": "^10.1.1",
+    "fast-deep-equal": "^3.1.3",
     "id128": "^1.6.6",
     "mongodb": "^5.8.0",
     "redis": "^4.6.11",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -22,6 +22,11 @@ export class AppController {
     await this.importService.importFromMongo(from, skip);
   }
 
+  @Get('updatetags')
+  async updateTags(@Query('updateid') updateId) {
+    await this.importService.updateTags(false, updateId);
+  }
+
   parseBoolean(value) {
     return value == true || value?.toLowerCase() == 'true';
   }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -24,7 +24,7 @@ export class AppController {
 
   @Get('updatetags')
   async updateTags(@Query('updateid') updateId) {
-    await this.importService.updateTags( updateId, true);
+    await this.importService.updateTags(updateId, true);
   }
 
   parseBoolean(value) {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -24,7 +24,7 @@ export class AppController {
 
   @Get('updatetags')
   async updateTags(@Query('updateid') updateId) {
-    await this.importService.updateTags(false, updateId);
+    await this.importService.updateTags( updateId, true);
   }
 
   parseBoolean(value) {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -22,6 +22,11 @@ export class AppController {
     await this.importService.importFromMongo(from, skip);
   }
 
+  @Get('scheduledimportfrommongo')
+  async scheduledImportFromMongo() {
+    await this.importService.scheduledImportFromMongo();
+  }
+
   @Get('updatetags')
   async updateTags(@Query('updateid') updateId) {
     await this.importService.updateTags(updateId, true);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,7 +15,11 @@ export class AppModule {
   constructor(
     private readonly em: EntityManager,
     private readonly importService: ImportService,
-  ) {}
+  ) {
+    RequestContext.create(this.em, () => {
+      importService.startRedisConsumer();
+    });
+  }
 
   // Refresh the PostgreSQL database from MongoDB at 2am every night
   @Cron('00 02 * * *')

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,32 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { DomainModule } from './domain/domain.module';
 import { HealthModule } from './health/health.module';
-import { Cron, ScheduleModule } from '@nestjs/schedule';
-import { EntityManager, RequestContext } from '@mikro-orm/core';
-import { ImportService } from './domain/services/import.service';
 
 @Module({
-  imports: [DomainModule, HealthModule, ScheduleModule.forRoot()],
+  imports: [DomainModule, HealthModule],
   controllers: [AppController],
   providers: [],
 })
-export class AppModule {
-  constructor(
-    private readonly em: EntityManager,
-    private readonly importService: ImportService,
-  ) {
-    RequestContext.create(this.em, () => {
-      importService.startRedisConsumer();
-    });
-  }
-
-  // Refresh the PostgreSQL database from MongoDB at 2am every night
-  @Cron('00 02 * * *')
-  async refreshProducts() {
-    // The request context creates a separate entity manager instance
-    // which avoids clashes with other requests
-    await RequestContext.createAsync(this.em, async () => {
-      await this.importService.scheduledImportFromMongo();
-    });
-  }
-}
+export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,7 +27,7 @@ export class AppModule {
     // The request context creates a separate entity manager instance
     // which avoids clashes with other requests
     await RequestContext.createAsync(this.em, async () => {
-      await this.importService.importFromMongo('');
+      await this.importService.scheduledImportFromMongo();
     });
   }
 }

--- a/src/domain/domain.module.ts
+++ b/src/domain/domain.module.ts
@@ -1,13 +1,41 @@
 import { MikroOrmModule } from '@mikro-orm/nestjs';
-import { Module } from '@nestjs/common';
+import { Module, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { ImportService } from './services/import.service';
 import { QueryService } from './services/query.service';
 import { TagService } from './services/tag.service';
 import { SettingsService } from './services/settings.service';
+import { EntityManager, RequestContext } from '@mikro-orm/core';
+import { Cron, ScheduleModule } from '@nestjs/schedule';
 
 @Module({
-  imports: [MikroOrmModule.forRoot()],
+  imports: [MikroOrmModule.forRoot(), ScheduleModule.forRoot()],
   providers: [ImportService, QueryService, TagService, SettingsService],
   exports: [ImportService, QueryService, TagService, SettingsService],
 })
-export class DomainModule {}
+export class DomainModule implements OnModuleInit, OnModuleDestroy {
+  constructor(
+    private readonly em: EntityManager,
+    private readonly importService: ImportService,
+  ) {}
+
+  async onModuleInit() {
+    RequestContext.create(this.em, () => {
+      this.importService.startRedisConsumer();
+    });
+  }
+
+  async onModuleDestroy() {
+    await this.importService.stopRedisConsumer();
+  }
+
+  // Refresh the PostgreSQL database from MongoDB at 2am every night
+  //@Cron('0 * * * * *') // Every minute for testing
+  @Cron('00 02 * * *')
+  async refreshProducts() {
+    // The request context creates a separate entity manager instance
+    // which avoids clashes with other requests
+    await RequestContext.createAsync(this.em, async () => {
+      await this.importService.scheduledImportFromMongo();
+    });
+  }
+}

--- a/src/domain/domain.module.ts
+++ b/src/domain/domain.module.ts
@@ -3,10 +3,11 @@ import { Module } from '@nestjs/common';
 import { ImportService } from './services/import.service';
 import { QueryService } from './services/query.service';
 import { TagService } from './services/tag.service';
+import { SettingsService } from './services/settings.service';
 
 @Module({
   imports: [MikroOrmModule.forRoot()],
-  providers: [ImportService, QueryService, TagService],
-  exports: [ImportService, QueryService, TagService],
+  providers: [ImportService, QueryService, TagService, SettingsService],
+  exports: [ImportService, QueryService, TagService, SettingsService],
 })
 export class DomainModule {}

--- a/src/domain/entities/product-ingredient.ts
+++ b/src/domain/entities/product-ingredient.ts
@@ -1,0 +1,51 @@
+import {
+  Collection,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/core';
+import { Product } from './product';
+
+@Entity()
+export class ProductIngredient {
+  @ManyToOne({ primary: true, onDelete: 'cascade' })
+  product: Product;
+
+  @PrimaryKey()
+  sequence: string;
+
+  @ManyToOne({ index: true })
+  parent?: ProductIngredient;
+
+  @Property()
+  ingredientText?: string;
+
+  @Property()
+  id?: string;
+
+  @Property()
+  ciqualFoodCode?: string;
+
+  @Property({ type: 'double' })
+  percentMin?: number;
+
+  @Property({ type: 'double' })
+  percent?: number;
+
+  @Property({ type: 'double' })
+  percentMax?: number;
+
+  @Property({ type: 'double' })
+  percentEstimate?: number;
+
+  @Property({ type: 'json', columnType: 'json' })
+  data?: any;
+
+  @OneToMany(() => ProductIngredient, (e) => e.parent)
+  ingredients = new Collection<ProductIngredient>(this);
+
+  @Property()
+  obsolete = false;
+}

--- a/src/domain/entities/product-ingredient.ts
+++ b/src/domain/entities/product-ingredient.ts
@@ -31,8 +31,8 @@ export class ProductIngredient {
   @Property({ type: 'double' })
   percentMin?: number;
 
-  @Property({ type: 'double' })
-  percent?: number;
+  @Property()
+  percent?: string;
 
   @Property({ type: 'double' })
   percentMax?: number;

--- a/src/domain/entities/product-tag-map.ts
+++ b/src/domain/entities/product-tag-map.ts
@@ -1,7 +1,6 @@
 export class ProductTagMap {
-    static MAPPED_TAGS: { [tag: string] : any; } = {};
-    static mapTag(name, entityClass) {
-        this.MAPPED_TAGS[name] = entityClass;
-    }
+  static MAPPED_TAGS: { [tag: string]: any } = {};
+  static mapTag(name, entityClass) {
+    this.MAPPED_TAGS[name] = entityClass;
+  }
 }
-

--- a/src/domain/entities/product-tags.ts
+++ b/src/domain/entities/product-tags.ts
@@ -93,9 +93,8 @@ export class ProductIngredientsThatMayBeFromPalmOilTag extends BaseProductTag {}
 //export class Product Tag extends BaseProductTag {}
 @ProductTag('last_image_dates_tags')
 export class ProductLatestImageDatesTag extends BaseProductTag {}
-// This is a scaler
-//@ProductTag('numbers_of_ingredients')
-//export class Product Tag extends BaseProductTag {}
+@ProductTag('ingredients_n_tags')
+export class ProductIngredientsNTag extends BaseProductTag {}
 @ProductTag('nutrient_levels_tags')
 export class ProductNutrientLevelsTag extends BaseProductTag {}
 // This is a hash

--- a/src/domain/entities/product-tags.ts
+++ b/src/domain/entities/product-tags.ts
@@ -62,9 +62,9 @@ export class ProductTeamsTag extends BaseProductTag {}
 export class ProductKeywordsTag extends BaseProductTag {}
 @ProductTag('codes_tags')
 export class ProductCodesTag extends BaseProductTag {}
-@ProductTag('data_quality_tags')
-export class ProductDataQualityErrorsTag extends BaseProductTag {}
 @ProductTag('data_quality_errors_tags')
+export class ProductDataQualityErrorsTag extends BaseProductTag {}
+@ProductTag('data_quality_tags')
 export class ProductDataQualityTag extends BaseProductTag {}
 @ProductTag('editors_tags')
 export class ProductEditorsTag extends BaseProductTag {}

--- a/src/domain/entities/product-tags.ts
+++ b/src/domain/entities/product-tags.ts
@@ -73,6 +73,84 @@ export class ProductStoresTag extends BaseProductTag {}
 @ProductTag('ingredients_original_tags')
 export class ProductIngredientsOriginalTag extends BaseProductTag {}
 
+// From Issue #22
+@ProductTag('checkers_tags')
+export class ProductCheckersTag extends BaseProductTag {}
+@ProductTag('cities_tags')
+export class ProductCitiesTag extends BaseProductTag {}
+@ProductTag('correctors_tags')
+export class ProductCorrectorsTag extends BaseProductTag {}
+@ProductTag('debug_tags')
+export class ProductDebugTag extends BaseProductTag {}
+@ProductTag('informers_tags')
+export class ProductInformersTag extends BaseProductTag {}
+@ProductTag('ingredients_from_palm_oil_tags')
+export class ProductIngredientsFromPalmOilTag extends BaseProductTag {}
+@ProductTag('ingredients_that_may_be_from_palm_oil_tags')
+export class ProductIngredientsThatMayBeFromPalmOilTag extends BaseProductTag {}
+//@ProductTag('known_nutrients')
+//export class Product Tag extends BaseProductTag {}
+@ProductTag('last_image_dates_tags')
+export class ProductLatestImageDatesTag extends BaseProductTag {}
+//@ProductTag('numbers_of_ingredients')
+//export class Product Tag extends BaseProductTag {}
+@ProductTag('nutrient_levels_tags')
+export class ProductNutrientLevelsTag extends BaseProductTag {}
+//@ProductTag('packager_codes')
+//export class Product Tag extends BaseProductTag {}
+//@ProductTag('periods_after_opening')
+//export class Product Tag extends BaseProductTag {}
+@ProductTag('photographers_tags')
+export class ProductPhotographersTag extends BaseProductTag {}
+@ProductTag('pnns_groups_1_tags')
+export class ProductPnnsGroups1Tag extends BaseProductTag {}
+@ProductTag('pnns_groups_2_tags')
+export class ProductPnnsGroups2Tag extends BaseProductTag {}
+@ProductTag('purchase_places_tags')
+export class ProductPurchasePlacesTag extends BaseProductTag {}
+@ProductTag('unknown_nutrients_tags')
+export class ProductUnknownNutrientsTag extends BaseProductTag {}
+//@ProductTag('contributors')
+//export class Product Tag extends BaseProductTag {}
+//@ProductTag('last_check_dates')
+//export class Product Tag extends BaseProductTag {}
+@ProductTag('popularity_tags')
+export class ProductPopularityTag extends BaseProductTag {}
+@ProductTag('ingredients_analysis_tags')
+export class ProductIngredientsAnalysisTag extends BaseProductTag {}
+@ProductTag('data_quality_bugs_tags')
+export class ProductDataQualityBugsTag extends BaseProductTag {}
+@ProductTag('data_quality_warnings_tags')
+export class ProductDataQualityWarningsTag extends BaseProductTag {}
+//@ProductTag('data_quality_warnings_producers')
+//export class Product Tag extends BaseProductTag {}
+//@ProductTag('data_quality_errors_producers')
+//export class Product Tag extends BaseProductTag {}
+//@ProductTag('possible_improvements')
+//export class Product Tag extends BaseProductTag {}
+//@ProductTag('imports')
+//export class Product Tag extends BaseProductTag {}
+@ProductTag('categories_properties_tags')
+export class ProductCategoriesProperitesTag extends BaseProductTag {}
+//@ProductTag('owners_tags')
+//export class ProductOwnersTag extends BaseProductTag {}
+@ProductTag('food_groups_tags')
+export class ProductFoodGroupsTag extends BaseProductTag {}
+@ProductTag('weighers_tags')
+export class ProductWeighersTag extends BaseProductTag {}
+@ProductTag('packaging_shapes_tags')
+export class ProductPackagingShapesTag extends BaseProductTag {}
+@ProductTag('packaging_materials_tags')
+export class ProductPackagingMaterialsTag extends BaseProductTag {}
+@ProductTag('packaging_recycling_tags')
+export class ProductPackagingRecyclingTag extends BaseProductTag {}
+@ProductTag('nutriscore_tags')
+export class ProductNutriscoreTag extends BaseProductTag {}
+@ProductTag('nutriscore_2021_tags')
+export class ProductNutriscore2021Tag extends BaseProductTag {}
+@ProductTag('nutriscore_2023_tags')
+export class ProductNutriscore2023Tag extends BaseProductTag {}
+
 /* From Config_off.pm
 # fields for drilldown facet navigation
 

--- a/src/domain/entities/product-tags.ts
+++ b/src/domain/entities/product-tags.ts
@@ -88,18 +88,21 @@ export class ProductInformersTag extends BaseProductTag {}
 export class ProductIngredientsFromPalmOilTag extends BaseProductTag {}
 @ProductTag('ingredients_that_may_be_from_palm_oil_tags')
 export class ProductIngredientsThatMayBeFromPalmOilTag extends BaseProductTag {}
+// Not found in PO
 //@ProductTag('known_nutrients')
 //export class Product Tag extends BaseProductTag {}
 @ProductTag('last_image_dates_tags')
 export class ProductLatestImageDatesTag extends BaseProductTag {}
+// This is a scaler
 //@ProductTag('numbers_of_ingredients')
 //export class Product Tag extends BaseProductTag {}
 @ProductTag('nutrient_levels_tags')
 export class ProductNutrientLevelsTag extends BaseProductTag {}
+// This is a hash
 //@ProductTag('packager_codes')
 //export class Product Tag extends BaseProductTag {}
-//@ProductTag('periods_after_opening')
-//export class Product Tag extends BaseProductTag {}
+@ProductTag('periods_after_opening_tags')
+export class ProductPeriodsAfterOpeningTag extends BaseProductTag {}
 @ProductTag('photographers_tags')
 export class ProductPhotographersTag extends BaseProductTag {}
 @ProductTag('pnns_groups_1_tags')
@@ -110,9 +113,8 @@ export class ProductPnnsGroups2Tag extends BaseProductTag {}
 export class ProductPurchasePlacesTag extends BaseProductTag {}
 @ProductTag('unknown_nutrients_tags')
 export class ProductUnknownNutrientsTag extends BaseProductTag {}
+// Thing this is editors
 //@ProductTag('contributors')
-//export class Product Tag extends BaseProductTag {}
-//@ProductTag('last_check_dates')
 //export class Product Tag extends BaseProductTag {}
 @ProductTag('popularity_tags')
 export class ProductPopularityTag extends BaseProductTag {}
@@ -122,6 +124,7 @@ export class ProductIngredientsAnalysisTag extends BaseProductTag {}
 export class ProductDataQualityBugsTag extends BaseProductTag {}
 @ProductTag('data_quality_warnings_tags')
 export class ProductDataQualityWarningsTag extends BaseProductTag {}
+// Can;t see these in PO
 //@ProductTag('data_quality_warnings_producers')
 //export class Product Tag extends BaseProductTag {}
 //@ProductTag('data_quality_errors_producers')
@@ -132,6 +135,7 @@ export class ProductDataQualityWarningsTag extends BaseProductTag {}
 //export class Product Tag extends BaseProductTag {}
 @ProductTag('categories_properties_tags')
 export class ProductCategoriesProperitesTag extends BaseProductTag {}
+// This is a scalar
 //@ProductTag('owners_tags')
 //export class ProductOwnersTag extends BaseProductTag {}
 @ProductTag('food_groups_tags')

--- a/src/domain/entities/product.ts
+++ b/src/domain/entities/product.ts
@@ -6,7 +6,7 @@ export class Product {
   @PrimaryKey({ type: 'uuid' })
   id = Ulid.generate().toRaw();
 
-  @Property({ type: 'jsonb' })
+  @Property({ type: 'json', columnType: 'json' })
   data?: any;
 
   @Property()
@@ -36,6 +36,12 @@ export class Product {
 
   @Property()
   obsolete = false;
+
+  @Property()
+  ingredientsWithoutCiqualCodesCount?: number;
+
+  @Property()
+  ingredientsCount?: number;
 }
 
 export const MAPPED_FIELDS = [
@@ -44,4 +50,7 @@ export const MAPPED_FIELDS = [
   'creator',
   'owners_tags',
   'last_modified_t',
+  'ingredients_n',
+  'ingredients_without_ciqual_codes_n',
+  'ingredients',
 ];

--- a/src/domain/entities/product.ts
+++ b/src/domain/entities/product.ts
@@ -1,14 +1,17 @@
 import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 import { Ulid } from 'id128';
+import { ProductSource } from '../enums/product-source';
 
 @Entity()
 export class Product {
   @PrimaryKey({ type: 'uuid' })
   id = Ulid.generate().toRaw();
 
+  /** The full JSON structure retreived from Product Opener */
   @Property({ type: 'json', columnType: 'json' })
   data?: any;
 
+  // The following fields map directly to Product fields
   @Property()
   name?: string;
 
@@ -31,17 +34,24 @@ export class Product {
   @Property()
   ownersTags?: string;
 
-  @Property({ type: 'uuid', index: true })
-  lastUpdateId?: string;
-
-  @Property()
-  obsolete = false;
-
   @Property()
   ingredientsWithoutCiqualCodesCount?: number;
 
   @Property()
   ingredientsCount?: number;
+
+  // The followign fields are populated by the query service
+  @Property()
+  obsolete = false;
+
+  @Property({ type: 'uuid', index: true })
+  lastUpdateId?: string;
+
+  @Property()
+  lastUpdated?: Date;
+
+  @Property()
+  source?: ProductSource;
 }
 
 export const MAPPED_FIELDS = [

--- a/src/domain/entities/settings.ts
+++ b/src/domain/entities/settings.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+
+@Entity()
+export class Settings {
+  @PrimaryKey()
+  id = 1;
+
+  @Property()
+  lastModified?: Date;
+}

--- a/src/domain/entities/settings.ts
+++ b/src/domain/entities/settings.ts
@@ -7,4 +7,7 @@ export class Settings {
 
   @Property()
   lastModified?: Date;
+
+  @Property()
+  lastMessageId?: string;
 }

--- a/src/domain/enums/product-source.ts
+++ b/src/domain/enums/product-source.ts
@@ -1,0 +1,5 @@
+export enum ProductSource {
+  INCREMENTAL_LOAD = 'incremental',
+  FULL_LOAD = 'full',
+  EVENT = 'event',
+}

--- a/src/domain/services/import.service.spec.ts
+++ b/src/domain/services/import.service.spec.ts
@@ -7,24 +7,29 @@ import { createTestingModule, randomCode } from '../../../test/test.helper';
 import { TagService } from './tag.service';
 import { LoadedTag } from '../entities/loaded-tag';
 import { ProductTagMap } from '../entities/product-tag-map';
+import { ProductSource } from '../enums/product-source';
 
 let index = 0;
-const productIdNew = randomCode();
-const productIdExisting = randomCode();
-const products = [
-  {
-    // This one will be new
-    code: productIdNew,
-    last_modified_t: 1692032161,
-    ingredients_tags: ['test'],
-  },
-  {
-    // This one will already exist
-    code: productIdExisting,
-    last_modified_t: 1692032161,
-    ingredients_tags: ['new_ingredient', 'old_ingredient'],
-  },
-];
+
+function testProducts() {
+  const productIdNew = randomCode();
+  const productIdExisting = randomCode();
+  const products = [
+    {
+      // This one will be new
+      code: productIdNew,
+      last_modified_t: 1692032161,
+      ingredients_tags: ['test'],
+    },
+    {
+      // This one will already exist
+      code: productIdExisting,
+      last_modified_t: 1692032161,
+      ingredients_tags: ['new_ingredient', 'old_ingredient'],
+    },
+  ];
+  return { products, productIdExisting, productIdNew };
+}
 
 jest.mock('mongodb', () => {
   return {
@@ -68,6 +73,7 @@ describe('importFromMongo', () => {
 
       // GIVEN: Two existing products, one of which is in Mongo plus one new one in Mongo
       const em = app.get(EntityManager);
+      const { products, productIdExisting, productIdNew } = testProducts();
       const productExisting = em.create(Product, { code: productIdExisting });
       em.create(ProductIngredientsTag, {
         product: productExisting,
@@ -86,6 +92,7 @@ describe('importFromMongo', () => {
 
       // WHEN:Doing a full import from MongoDB
       mockMongoDB(products);
+      const start = Date.now();
       await importService.importFromMongo();
 
       // THEN: New product is addeded, updated product is updated and other product is unchanged
@@ -102,6 +109,8 @@ describe('importFromMongo', () => {
       const productNew = await em.findOne(Product, { code: productIdNew });
       expect(productNew).toBeTruthy();
       expect(productNew.lastUpdateId).toBe(updateId);
+      expect(productNew.source).toBe(ProductSource.FULL_LOAD);
+      expect(productNew.lastUpdated.getTime()).toBeGreaterThanOrEqual(start);
       const ingredientsNew = await em.find(ProductIngredientsTag, {
         product: productNew,
       });
@@ -127,7 +136,9 @@ describe('importFromMongo', () => {
       expect(foundOldProduct.lastUpdateId).not.toBe(updateId);
 
       const loadedTags = await app.get(TagService).getLoadedTags();
-      expect(loadedTags).toHaveLength(Object.keys(ProductTagMap.MAPPED_TAGS).length);
+      expect(loadedTags).toHaveLength(
+        Object.keys(ProductTagMap.MAPPED_TAGS).length,
+      );
     });
   });
 
@@ -140,18 +151,52 @@ describe('importFromMongo', () => {
       const importService = app.get(ImportService);
 
       // WHEN: Doing an incremental import from MongoDB
+      const { products, productIdNew } = testProducts();
       mockMongoDB(products);
       await importService.importFromMongo('');
 
       // THEN: Loaded tags is not updated
       const loadedTags = await app.get(TagService).getLoadedTags();
       expect(loadedTags).not.toContain('teams_tags');
+
+      const productNew = await em.findOne(Product, { code: productIdNew });
+      expect(productNew).toBeTruthy();
+      expect(productNew.source).toBe(ProductSource.INCREMENTAL_LOAD);
+    });
+  });
+
+  it('import with no change should not update the source', async () => {
+    await createTestingModule([DomainModule], async (app) => {
+      // GIVEN: Product with data that matches MongoDB
+      const em = app.get(EntityManager);
+      const lastUpdated = new Date(2023, 1, 1);
+      const { products, productIdExisting } = testProducts();
+      em.create(Product, {
+        code: productIdExisting,
+        data: products[1],
+        source: ProductSource.EVENT,
+        lastUpdated: lastUpdated,
+      });
+      const importService = app.get(ImportService);
+
+      // WHEN: Doing an incremental import from MongoDB
+      mockMongoDB(products);
+      await importService.importFromMongo('');
+
+      // THEN: Source is not updated
+      const productExisting = await em.findOne(Product, {
+        code: productIdExisting,
+      });
+      expect(productExisting).toBeTruthy();
+      expect(productExisting.source).toBe(ProductSource.EVENT);
+      expect(productExisting.lastUpdated).toStrictEqual(lastUpdated);
     });
   });
 
   it('should cope with nul charactes', async () => {
     await createTestingModule([DomainModule], async (app) => {
       // WHEN: Impoting data containing nul characters
+      const { productIdNew } = testProducts();
       mockMongoDB([
         {
           // This one will be new
@@ -176,9 +221,9 @@ describe('importFromMongo', () => {
 });
 
 describe('ProductTag', () => {
-    it('should add class to tag array', async () => {
-        await createTestingModule([DomainModule], async (app) => {
-            expect(ProductTagMap.MAPPED_TAGS['categories_tags']).toBeTruthy();
-        });
+  it('should add class to tag array', async () => {
+    await createTestingModule([DomainModule], async (app) => {
+      expect(ProductTagMap.MAPPED_TAGS['categories_tags']).toBeTruthy();
     });
+  });
 });

--- a/src/domain/services/import.service.spec.ts
+++ b/src/domain/services/import.service.spec.ts
@@ -220,6 +220,40 @@ describe('importFromMongo', () => {
   });
 });
 
+describe('scheduledImportFromMongo', () => {
+  it('should do a full import if loaded tags arent complete', async () => {
+    await createTestingModule([DomainModule], async (app) => {
+      const importService = app.get(ImportService);
+      jest
+        .spyOn(app.get(TagService), 'getLoadedTags')
+        .mockImplementation(async () => []);
+      const importSpy = jest
+        .spyOn(importService, 'importFromMongo')
+        .mockImplementation();
+      await importService.scheduledImportFromMongo();
+      expect(importSpy).toHaveBeenCalledTimes(1);
+      expect(importSpy.mock.calls[0][0]).toBeUndefined();
+    });
+  });
+
+  it('should do an incremental import if loaded tags are complete', async () => {
+    await createTestingModule([DomainModule], async (app) => {
+      const importService = app.get(ImportService);
+      jest
+        .spyOn(app.get(TagService), 'getLoadedTags')
+        .mockImplementation(async () =>
+          Object.keys(ProductTagMap.MAPPED_TAGS).reverse(),
+        );
+      const importSpy = jest
+        .spyOn(importService, 'importFromMongo')
+        .mockImplementation();
+      await importService.scheduledImportFromMongo();
+      expect(importSpy).toHaveBeenCalledTimes(1);
+      expect(importSpy.mock.calls[0][0]).toBe('');
+    });
+  });
+});
+
 describe('ProductTag', () => {
   it('should add class to tag array', async () => {
     await createTestingModule([DomainModule], async (app) => {

--- a/src/domain/services/import.service.spec.ts
+++ b/src/domain/services/import.service.spec.ts
@@ -286,7 +286,7 @@ describe('scheduledImportFromMongo', () => {
 
 describe('ProductTag', () => {
   it('should add class to tag array', async () => {
-    await createTestingModule([DomainModule], async (app) => {
+    await createTestingModule([DomainModule], async () => {
       expect(ProductTagMap.MAPPED_TAGS['categories_tags']).toBeTruthy();
     });
   });

--- a/src/domain/services/import.service.spec.ts
+++ b/src/domain/services/import.service.spec.ts
@@ -304,7 +304,6 @@ describe('ProductTag', () => {
 });
 
 describe('receiveMessages', () => {
-  jest.setTimeout(600000);
   it('should call importwithfilter when a message is received', async () => {
     await createTestingModule([DomainModule], async (app) => {
       // GIVEN: Redis is running

--- a/src/domain/services/import.service.ts
+++ b/src/domain/services/import.service.ts
@@ -333,6 +333,20 @@ export class ImportService {
     this.logger.log(`${deleted} Products deleted`);
   }
 
+  async scheduledImportFromMongo() {
+    if (
+      equal(
+        Object.keys(ProductTagMap.MAPPED_TAGS).sort(),
+        (await this.tagService.getLoadedTags()).sort(),
+      )
+    ) {
+      // Do an incremental load if all tags are already loaded
+      await this.importFromMongo('');
+    } else {
+      await this.importFromMongo();
+    }
+  }
+
   async startRedisConsumer() {
     const redisUrl = process.env['REDIS_URL'];
     if (!redisUrl) return;

--- a/src/domain/services/import.service.ts
+++ b/src/domain/services/import.service.ts
@@ -142,13 +142,17 @@ export class ImportService {
       const tagData = data[key] as string[];
       if (tagData) {
         // Strip out any nul characters
-        for (const [index, value] of tagData.entries()) {
-          if (value.includes('\u0000')) {
-            this.logger.warn(
-              `Product: ${data.code}. Nuls stripped from ${key} value: ${value}`,
-            );
-            tagData[index] = value.replace(this.nulRegex, '');
+        try {
+          for (const [index, value] of tagData.entries()) {
+            if (value.includes('\u0000')) {
+              this.logger.warn(
+                `Product: ${data.code}. Nuls stripped from ${key} value: ${value}`,
+              );
+              tagData[index] = value.replace(this.nulRegex, '');
+            }
           }
+        } catch (e) {
+          this.logger.error(`${key}: ${e.message}`);
         }
       }
     }

--- a/src/domain/services/import.service.ts
+++ b/src/domain/services/import.service.ts
@@ -42,7 +42,7 @@ export class ImportService {
     if (from) {
       const fromTime = Math.floor(new Date(from).getTime() / 1000);
       filter['last_modified_t'] = { $gt: fromTime };
-      this.logger.log(`Starting import from $[from}`);
+      this.logger.log(`Starting import from ${from}`);
     }
 
     await this.importWithFilter(filter, skip);

--- a/src/domain/services/query.service.spec.ts
+++ b/src/domain/services/query.service.spec.ts
@@ -437,9 +437,7 @@ describe('select', () => {
 
   it('should cope with $nin', async () => {
     await createTestingModule([DomainModule], async (app) => {
-      const { originValue, aminoValue, product3 } = await createTestTags(
-        app,
-      );
+      const { originValue, aminoValue, product3 } = await createTestTags(app);
       const queryService = app.get(QueryService);
       const response = await queryService.select({
         origins_tags: originValue,

--- a/src/domain/services/settings.service.ts
+++ b/src/domain/services/settings.service.ts
@@ -1,0 +1,16 @@
+import { EntityManager } from '@mikro-orm/core';
+import { Injectable } from '@nestjs/common';
+import { Settings } from '../entities/settings';
+
+@Injectable()
+export class SettingsService {
+  constructor(private readonly em: EntityManager) {}
+
+  async get() {
+    let settings = await this.em.findOne(Settings, 1);
+    if (!settings) {
+      settings = this.em.create(Settings, {});
+    }
+    return settings;
+  }
+}

--- a/src/domain/services/settings.service.ts
+++ b/src/domain/services/settings.service.ts
@@ -24,6 +24,15 @@ export class SettingsService {
     await this.em.flush();
   }
 
+  async getLastMessageId() {
+    return (await this.find()).lastMessageId || '$';
+  }
+
+  async setLastMessageId(messageId: string) {
+    (await this.find()).lastMessageId = messageId;
+    await this.em.flush();
+  }
+
   getRedisUrl() {
     return process.env.REDIS_URL;
   }

--- a/src/domain/services/settings.service.ts
+++ b/src/domain/services/settings.service.ts
@@ -6,11 +6,25 @@ import { Settings } from '../entities/settings';
 export class SettingsService {
   constructor(private readonly em: EntityManager) {}
 
-  async get() {
-    let settings = await this.em.findOne(Settings, 1);
-    if (!settings) {
-      settings = this.em.create(Settings, {});
+  settings: Settings;
+  async find() {
+    this.settings = await this.em.findOne(Settings, 1);
+    if (!this.settings) {
+      this.settings = this.em.create(Settings, {});
     }
-    return settings;
+    return this.settings;
+  }
+
+  async getLastModified() {
+    return (await this.find()).lastModified;
+  }
+
+  async setLastModified(lastModified: Date) {
+    (await this.find()).lastModified = lastModified;
+    await this.em.flush();
+  }
+
+  getRedisUrl() {
+    return process.env.REDIS_URL;
   }
 }

--- a/src/migrations/.snapshot-query.json
+++ b/src/migrations/.snapshot-query.json
@@ -98,25 +98,6 @@
           "nullable": true,
           "mappedType": "text"
         },
-        "last_update_id": {
-          "name": "last_update_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "uuid"
-        },
-        "obsolete": {
-          "name": "obsolete",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "false",
-          "mappedType": "boolean"
-        },
         "ingredients_without_ciqual_codes_count": {
           "name": "ingredients_without_ciqual_codes_count",
           "type": "int",
@@ -134,6 +115,44 @@
           "primary": false,
           "nullable": true,
           "mappedType": "integer"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        },
+        "last_update_id": {
+          "name": "last_update_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "uuid"
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "string"
         }
       },
       "name": "product",

--- a/src/migrations/.snapshot-query.json
+++ b/src/migrations/.snapshot-query.json
@@ -4860,6 +4860,15 @@
           "nullable": true,
           "length": 6,
           "mappedType": "datetime"
+        },
+        "last_message_id": {
+          "name": "last_message_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
         }
       },
       "name": "settings",

--- a/src/migrations/.snapshot-query.json
+++ b/src/migrations/.snapshot-query.json
@@ -1240,12 +1240,12 @@
         },
         "percent": {
           "name": "percent",
-          "type": "double precision",
+          "type": "text",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
-          "mappedType": "double"
+          "mappedType": "text"
         },
         "percent_max": {
           "name": "percent_max",

--- a/src/migrations/.snapshot-query.json
+++ b/src/migrations/.snapshot-query.json
@@ -504,6 +504,77 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_categories_properites_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_categories_properites_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_categories_properites_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_categories_properites_tag_product_id_foreign": {
+          "constraintName": "product_categories_properites_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_categories_properites_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_categories_tag",
       "schema": "query",
       "indexes": [
@@ -535,6 +606,148 @@
             "product_id"
           ],
           "localTableName": "query.product_categories_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_checkers_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_checkers_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_checkers_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_checkers_tag_product_id_foreign": {
+          "constraintName": "product_checkers_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_checkers_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_cities_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_cities_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_cities_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_cities_tag_product_id_foreign": {
+          "constraintName": "product_cities_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_cities_tag",
           "referencedColumnNames": [
             "id"
           ],
@@ -646,6 +859,77 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_correctors_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_correctors_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_correctors_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_correctors_tag_product_id_foreign": {
+          "constraintName": "product_correctors_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_correctors_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_countries_tag",
       "schema": "query",
       "indexes": [
@@ -677,6 +961,77 @@
             "product_id"
           ],
           "localTableName": "query.product_countries_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_data_quality_bugs_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_data_quality_bugs_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_data_quality_bugs_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_data_quality_bugs_tag_product_id_foreign": {
+          "constraintName": "product_data_quality_bugs_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_data_quality_bugs_tag",
           "referencedColumnNames": [
             "id"
           ],
@@ -859,6 +1214,77 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_data_quality_warnings_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_data_quality_warnings_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_data_quality_warnings_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_data_quality_warnings_tag_product_id_foreign": {
+          "constraintName": "product_data_quality_warnings_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_data_quality_warnings_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_data_sources_tag",
       "schema": "query",
       "indexes": [
@@ -890,6 +1316,77 @@
             "product_id"
           ],
           "localTableName": "query.product_data_sources_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_debug_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_debug_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_debug_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_debug_tag_product_id_foreign": {
+          "constraintName": "product_debug_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_debug_tag",
           "referencedColumnNames": [
             "id"
           ],
@@ -1194,6 +1691,148 @@
           "nullable": false,
           "mappedType": "uuid"
         },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_food_groups_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_food_groups_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_food_groups_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_food_groups_tag_product_id_foreign": {
+          "constraintName": "product_food_groups_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_food_groups_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_informers_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_informers_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_informers_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_informers_tag_product_id_foreign": {
+          "constraintName": "product_informers_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_informers_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
         "sequence": {
           "name": "sequence",
           "type": "text",
@@ -1391,6 +2030,148 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_ingredients_analysis_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_ingredients_analysis_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_ingredients_analysis_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_ingredients_analysis_tag_product_id_foreign": {
+          "constraintName": "product_ingredients_analysis_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_ingredients_analysis_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_ingredients_from_palm_oil_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_ingredients_from_palm_oil_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_ingredients_from_palm_oil_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_ingredients_from_palm_oil_tag_product_id_foreign": {
+          "constraintName": "product_ingredients_from_palm_oil_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_ingredients_from_palm_oil_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_ingredients_original_tag",
       "schema": "query",
       "indexes": [
@@ -1493,6 +2274,77 @@
             "product_id"
           ],
           "localTableName": "query.product_ingredients_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_ingredients_that_may_be_from_palm_oil_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_ingredients_that_may_be_from_palm_oil_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_ingredients_that_may_be_from_palm_oil_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_ingredients_that_may_be_from_palm_oil_tag_c5e4a_foreign": {
+          "constraintName": "product_ingredients_that_may_be_from_palm_oil_tag_c5e4a_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_ingredients_that_may_be_from_palm_oil_tag",
           "referencedColumnNames": [
             "id"
           ],
@@ -1888,6 +2740,77 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_latest_image_dates_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_latest_image_dates_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_latest_image_dates_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_latest_image_dates_tag_product_id_foreign": {
+          "constraintName": "product_latest_image_dates_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_latest_image_dates_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_manufacturing_places_tag",
       "schema": "query",
       "indexes": [
@@ -2243,6 +3166,290 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_nutrient_levels_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_nutrient_levels_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_nutrient_levels_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_nutrient_levels_tag_product_id_foreign": {
+          "constraintName": "product_nutrient_levels_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_nutrient_levels_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_nutriscore2021tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_nutriscore2021tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_nutriscore2021tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_nutriscore2021tag_product_id_foreign": {
+          "constraintName": "product_nutriscore2021tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_nutriscore2021tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_nutriscore2023tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_nutriscore2023tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_nutriscore2023tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_nutriscore2023tag_product_id_foreign": {
+          "constraintName": "product_nutriscore2023tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_nutriscore2023tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_nutriscore_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_nutriscore_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_nutriscore_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_nutriscore_tag_product_id_foreign": {
+          "constraintName": "product_nutriscore_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_nutriscore_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_nutrition_grades_tag",
       "schema": "query",
       "indexes": [
@@ -2456,6 +3663,290 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_owners_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_owners_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_owners_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_owners_tag_product_id_foreign": {
+          "constraintName": "product_owners_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_owners_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_packaging_materials_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_packaging_materials_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_packaging_materials_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_packaging_materials_tag_product_id_foreign": {
+          "constraintName": "product_packaging_materials_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_packaging_materials_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_packaging_recycling_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_packaging_recycling_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_packaging_recycling_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_packaging_recycling_tag_product_id_foreign": {
+          "constraintName": "product_packaging_recycling_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_packaging_recycling_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_packaging_shapes_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_packaging_shapes_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_packaging_shapes_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_packaging_shapes_tag_product_id_foreign": {
+          "constraintName": "product_packaging_shapes_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_packaging_shapes_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_packaging_tag",
       "schema": "query",
       "indexes": [
@@ -2487,6 +3978,361 @@
             "product_id"
           ],
           "localTableName": "query.product_packaging_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_photographers_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_photographers_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_photographers_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_photographers_tag_product_id_foreign": {
+          "constraintName": "product_photographers_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_photographers_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_pnns_groups1tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_pnns_groups1tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_pnns_groups1tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_pnns_groups1tag_product_id_foreign": {
+          "constraintName": "product_pnns_groups1tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_pnns_groups1tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_pnns_groups2tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_pnns_groups2tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_pnns_groups2tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_pnns_groups2tag_product_id_foreign": {
+          "constraintName": "product_pnns_groups2tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_pnns_groups2tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_popularity_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_popularity_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_popularity_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_popularity_tag_product_id_foreign": {
+          "constraintName": "product_popularity_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_popularity_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_purchase_places_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_purchase_places_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_purchase_places_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_purchase_places_tag_product_id_foreign": {
+          "constraintName": "product_purchase_places_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_purchase_places_tag",
           "referencedColumnNames": [
             "id"
           ],
@@ -2811,6 +4657,77 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_unknown_nutrients_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_unknown_nutrients_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_unknown_nutrients_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_unknown_nutrients_tag_product_id_foreign": {
+          "constraintName": "product_unknown_nutrients_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_unknown_nutrients_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_vitamins_tag",
       "schema": "query",
       "indexes": [
@@ -2842,6 +4759,77 @@
             "product_id"
           ],
           "localTableName": "query.product_vitamins_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_weighers_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_weighers_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_weighers_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_weighers_tag_product_id_foreign": {
+          "constraintName": "product_weighers_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_weighers_tag",
           "referencedColumnNames": [
             "id"
           ],

--- a/src/migrations/.snapshot-query.json
+++ b/src/migrations/.snapshot-query.json
@@ -3663,77 +3663,6 @@
           "mappedType": "boolean"
         }
       },
-      "name": "product_owners_tag",
-      "schema": "query",
-      "indexes": [
-        {
-          "columnNames": [
-            "value"
-          ],
-          "composite": false,
-          "keyName": "product_owners_tag_value_index",
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "product_owners_tag_pkey",
-          "columnNames": [
-            "product_id",
-            "value"
-          ],
-          "composite": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "product_owners_tag_product_id_foreign": {
-          "constraintName": "product_owners_tag_product_id_foreign",
-          "columnNames": [
-            "product_id"
-          ],
-          "localTableName": "query.product_owners_tag",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "query.product",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        }
-      }
-    },
-    {
-      "columns": {
-        "product_id": {
-          "name": "product_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "uuid"
-        },
-        "value": {
-          "name": "value",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "text"
-        },
-        "obsolete": {
-          "name": "obsolete",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "false",
-          "mappedType": "boolean"
-        }
-      },
       "name": "product_packaging_materials_tag",
       "schema": "query",
       "indexes": [
@@ -3978,6 +3907,77 @@
             "product_id"
           ],
           "localTableName": "query.product_packaging_tag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_periods_after_opening_tag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_periods_after_opening_tag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_periods_after_opening_tag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_periods_after_opening_tag_product_id_foreign": {
+          "constraintName": "product_periods_after_opening_tag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_periods_after_opening_tag",
           "referencedColumnNames": [
             "id"
           ],

--- a/src/migrations/.snapshot-query.json
+++ b/src/migrations/.snapshot-query.json
@@ -2172,6 +2172,77 @@
           "mappedType": "boolean"
         }
       },
+      "name": "product_ingredients_ntag",
+      "schema": "query",
+      "indexes": [
+        {
+          "columnNames": [
+            "value"
+          ],
+          "composite": false,
+          "keyName": "product_ingredients_ntag_value_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_ingredients_ntag_pkey",
+          "columnNames": [
+            "product_id",
+            "value"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_ingredients_ntag_product_id_foreign": {
+          "constraintName": "product_ingredients_ntag_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_ingredients_ntag",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
       "name": "product_ingredients_original_tag",
       "schema": "query",
       "indexes": [

--- a/src/migrations/.snapshot-query.json
+++ b/src/migrations/.snapshot-query.json
@@ -45,7 +45,7 @@
         },
         "data": {
           "name": "data",
-          "type": "jsonb",
+          "type": "json",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -116,6 +116,24 @@
           "nullable": false,
           "default": "false",
           "mappedType": "boolean"
+        },
+        "ingredients_without_ciqual_codes_count": {
+          "name": "ingredients_without_ciqual_codes_count",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "integer"
+        },
+        "ingredients_count": {
+          "name": "ingredients_count",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "integer"
         }
       },
       "name": "product",
@@ -1142,6 +1160,183 @@
           ],
           "referencedTableName": "query.product",
           "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
+    },
+    {
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "parent_product_id": {
+          "name": "parent_product_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "uuid"
+        },
+        "parent_sequence": {
+          "name": "parent_sequence",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
+        "ingredient_text": {
+          "name": "ingredient_text",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
+        "ciqual_food_code": {
+          "name": "ciqual_food_code",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
+        "percent_min": {
+          "name": "percent_min",
+          "type": "double precision",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "double"
+        },
+        "percent": {
+          "name": "percent",
+          "type": "double precision",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "double"
+        },
+        "percent_max": {
+          "name": "percent_max",
+          "type": "double precision",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "double"
+        },
+        "percent_estimate": {
+          "name": "percent_estimate",
+          "type": "double precision",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "double"
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "obsolete": {
+          "name": "obsolete",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        }
+      },
+      "name": "product_ingredient",
+      "schema": "query",
+      "indexes": [
+        {
+          "keyName": "product_ingredient_parent_product_id_parent_sequence_index",
+          "columnNames": [
+            "parent_product_id",
+            "parent_sequence"
+          ],
+          "composite": true,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "product_ingredient_pkey",
+          "columnNames": [
+            "product_id",
+            "sequence"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "product_ingredient_product_id_foreign": {
+          "constraintName": "product_ingredient_product_id_foreign",
+          "columnNames": [
+            "product_id"
+          ],
+          "localTableName": "query.product_ingredient",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "query.product",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
+        "product_ingredient_parent_product_id_parent_sequence_foreign": {
+          "constraintName": "product_ingredient_parent_product_id_parent_sequence_foreign",
+          "columnNames": [
+            "parent_product_id",
+            "parent_sequence"
+          ],
+          "localTableName": "query.product_ingredient",
+          "referencedColumnNames": [
+            "product_id",
+            "sequence"
+          ],
+          "referencedTableName": "query.product_ingredient",
+          "deleteRule": "set null",
           "updateRule": "cascade"
         }
       }

--- a/src/migrations/.snapshot-query.json
+++ b/src/migrations/.snapshot-query.json
@@ -2850,6 +2850,45 @@
           "updateRule": "cascade"
         }
       }
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "default": "1",
+          "mappedType": "integer"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 6,
+          "mappedType": "datetime"
+        }
+      },
+      "name": "settings",
+      "schema": "query",
+      "indexes": [
+        {
+          "keyName": "settings_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {}
     }
   ]
 }

--- a/src/migrations/Migration20231127180807.ts
+++ b/src/migrations/Migration20231127180807.ts
@@ -1,0 +1,46 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231127180807 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "query"."product_ingredient" ("product_id" uuid not null, "sequence" text not null, "parent_product_id" uuid null, "parent_sequence" text null, "ingredient_text" text null, "id" text null, "ciqual_food_code" text null, "percent_min" double precision null, "percent" double precision null, "percent_max" double precision null, "percent_estimate" double precision null, "data" json null, "obsolete" boolean not null default false, constraint "product_ingredient_pkey" primary key ("product_id", "sequence"));',
+    );
+    this.addSql(
+      'create index "product_ingredient_parent_product_id_parent_sequence_index" on "query"."product_ingredient" ("parent_product_id", "parent_sequence");',
+    );
+
+    this.addSql(
+      'alter table "query"."product_ingredient" add constraint "product_ingredient_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+    this.addSql(
+      'alter table "query"."product_ingredient" add constraint "product_ingredient_parent_product_id_parent_sequence_foreign" foreign key ("parent_product_id", "parent_sequence") references "query"."product_ingredient" ("product_id", "sequence") on update cascade on delete set null;',
+    );
+
+    this.addSql(
+      'ALTER TABLE query.product ALTER COLUMN "data" TYPE json USING "data"::text::json;',
+    );
+
+    this.addSql(
+      'alter table "query"."product" add column "ingredients_without_ciqual_codes_count" int null, add column "ingredients_count" int null;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql(
+      'alter table "query"."product_ingredient" drop constraint "product_ingredient_parent_product_id_parent_sequence_foreign";',
+    );
+
+    this.addSql('drop table if exists "query"."product_ingredient" cascade;');
+
+    this.addSql(
+      'ALTER TABLE query.product ALTER COLUMN "data" TYPE jsonb USING "data"::text::jsonb;',
+    );
+
+    this.addSql(
+      'alter table "query"."product" drop column "ingredients_without_ciqual_codes_count";',
+    );
+    this.addSql(
+      'alter table "query"."product" drop column "ingredients_count";',
+    );
+  }
+}

--- a/src/migrations/Migration20231201090312.ts
+++ b/src/migrations/Migration20231201090312.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231201090312 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "query"."product_ingredient" alter column "percent" type text using ("percent"::text);');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "query"."product_ingredient" alter column "percent" type double precision using ("percent"::double precision);');
+  }
+
+}

--- a/src/migrations/Migration20231201090312.ts
+++ b/src/migrations/Migration20231201090312.ts
@@ -1,13 +1,15 @@
 import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20231201090312 extends Migration {
-
   async up(): Promise<void> {
-    this.addSql('alter table "query"."product_ingredient" alter column "percent" type text using ("percent"::text);');
+    this.addSql(
+      'alter table "query"."product_ingredient" alter column "percent" type text using ("percent"::text);',
+    );
   }
 
   async down(): Promise<void> {
-    this.addSql('alter table "query"."product_ingredient" alter column "percent" type double precision using ("percent"::double precision);');
+    this.addSql(
+      'alter table "query"."product_ingredient" alter column "percent" type double precision using ("percent"::double precision);',
+    );
   }
-
 }

--- a/src/migrations/Migration20231216114832.ts
+++ b/src/migrations/Migration20231216114832.ts
@@ -1,0 +1,14 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231216114832 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'alter table "query"."product" add column "last_updated" timestamp null, add column "source" varchar(255) null;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "query"."product" drop column "last_updated";');
+    this.addSql('alter table "query"."product" drop column "source";');
+  }
+}

--- a/src/migrations/Migration20231216155931.ts
+++ b/src/migrations/Migration20231216155931.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231216155931 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "query"."settings" ("id" serial primary key, "last_modified" timestamp null);',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql('drop table if exists "query"."settings" cascade;');
+  }
+}

--- a/src/migrations/Migration20231216174233.ts
+++ b/src/migrations/Migration20231216174233.ts
@@ -1,0 +1,404 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231216174233 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "query"."product_categories_properites_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_categories_properites_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_categories_properites_tag_value_index" on "query"."product_categories_properites_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_checkers_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_checkers_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_checkers_tag_value_index" on "query"."product_checkers_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_cities_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_cities_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_cities_tag_value_index" on "query"."product_cities_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_correctors_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_correctors_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_correctors_tag_value_index" on "query"."product_correctors_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_data_quality_bugs_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_data_quality_bugs_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_data_quality_bugs_tag_value_index" on "query"."product_data_quality_bugs_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_data_quality_warnings_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_data_quality_warnings_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_data_quality_warnings_tag_value_index" on "query"."product_data_quality_warnings_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_debug_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_debug_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_debug_tag_value_index" on "query"."product_debug_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_food_groups_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_food_groups_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_food_groups_tag_value_index" on "query"."product_food_groups_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_informers_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_informers_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_informers_tag_value_index" on "query"."product_informers_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_ingredients_analysis_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_ingredients_analysis_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_ingredients_analysis_tag_value_index" on "query"."product_ingredients_analysis_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_ingredients_from_palm_oil_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_ingredients_from_palm_oil_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_ingredients_from_palm_oil_tag_value_index" on "query"."product_ingredients_from_palm_oil_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_ingredients_that_may_be_from_palm_oil_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_ingredients_that_may_be_from_palm_oil_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_ingredients_that_may_be_from_palm_oil_tag_value_index" on "query"."product_ingredients_that_may_be_from_palm_oil_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_latest_image_dates_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_latest_image_dates_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_latest_image_dates_tag_value_index" on "query"."product_latest_image_dates_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_nutrient_levels_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_nutrient_levels_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_nutrient_levels_tag_value_index" on "query"."product_nutrient_levels_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_nutriscore2021tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_nutriscore2021tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_nutriscore2021tag_value_index" on "query"."product_nutriscore2021tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_nutriscore2023tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_nutriscore2023tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_nutriscore2023tag_value_index" on "query"."product_nutriscore2023tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_nutriscore_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_nutriscore_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_nutriscore_tag_value_index" on "query"."product_nutriscore_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_packaging_materials_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_packaging_materials_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_packaging_materials_tag_value_index" on "query"."product_packaging_materials_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_packaging_recycling_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_packaging_recycling_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_packaging_recycling_tag_value_index" on "query"."product_packaging_recycling_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_packaging_shapes_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_packaging_shapes_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_packaging_shapes_tag_value_index" on "query"."product_packaging_shapes_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_photographers_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_photographers_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_photographers_tag_value_index" on "query"."product_photographers_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_pnns_groups1tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_pnns_groups1tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_pnns_groups1tag_value_index" on "query"."product_pnns_groups1tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_pnns_groups2tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_pnns_groups2tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_pnns_groups2tag_value_index" on "query"."product_pnns_groups2tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_popularity_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_popularity_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_popularity_tag_value_index" on "query"."product_popularity_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_purchase_places_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_purchase_places_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_purchase_places_tag_value_index" on "query"."product_purchase_places_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_unknown_nutrients_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_unknown_nutrients_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_unknown_nutrients_tag_value_index" on "query"."product_unknown_nutrients_tag" ("value");',
+    );
+
+    this.addSql(
+      'create table "query"."product_weighers_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_weighers_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_weighers_tag_value_index" on "query"."product_weighers_tag" ("value");',
+    );
+
+    this.addSql(
+      'alter table "query"."product_categories_properites_tag" add constraint "product_categories_properites_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_checkers_tag" add constraint "product_checkers_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_cities_tag" add constraint "product_cities_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_correctors_tag" add constraint "product_correctors_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_data_quality_bugs_tag" add constraint "product_data_quality_bugs_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_data_quality_warnings_tag" add constraint "product_data_quality_warnings_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_debug_tag" add constraint "product_debug_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_food_groups_tag" add constraint "product_food_groups_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_informers_tag" add constraint "product_informers_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_ingredients_analysis_tag" add constraint "product_ingredients_analysis_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_ingredients_from_palm_oil_tag" add constraint "product_ingredients_from_palm_oil_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_ingredients_that_may_be_from_palm_oil_tag" add constraint "product_ingredients_that_may_be_from_palm_oil_tag_c5e4a_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_latest_image_dates_tag" add constraint "product_latest_image_dates_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_nutrient_levels_tag" add constraint "product_nutrient_levels_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_nutriscore2021tag" add constraint "product_nutriscore2021tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_nutriscore2023tag" add constraint "product_nutriscore2023tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_nutriscore_tag" add constraint "product_nutriscore_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_packaging_materials_tag" add constraint "product_packaging_materials_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_packaging_recycling_tag" add constraint "product_packaging_recycling_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_packaging_shapes_tag" add constraint "product_packaging_shapes_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_photographers_tag" add constraint "product_photographers_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_pnns_groups1tag" add constraint "product_pnns_groups1tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_pnns_groups2tag" add constraint "product_pnns_groups2tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_popularity_tag" add constraint "product_popularity_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_purchase_places_tag" add constraint "product_purchase_places_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_unknown_nutrients_tag" add constraint "product_unknown_nutrients_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'alter table "query"."product_weighers_tag" add constraint "product_weighers_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql(
+      'drop table if exists "query"."product_categories_properites_tag" cascade;',
+    );
+
+    this.addSql('drop table if exists "query"."product_checkers_tag" cascade;');
+
+    this.addSql('drop table if exists "query"."product_cities_tag" cascade;');
+
+    this.addSql(
+      'drop table if exists "query"."product_correctors_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_data_quality_bugs_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_data_quality_warnings_tag" cascade;',
+    );
+
+    this.addSql('drop table if exists "query"."product_debug_tag" cascade;');
+
+    this.addSql(
+      'drop table if exists "query"."product_food_groups_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_informers_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_ingredients_analysis_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_ingredients_from_palm_oil_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_ingredients_that_may_be_from_palm_oil_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_latest_image_dates_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_nutrient_levels_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_nutriscore2021tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_nutriscore2023tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_nutriscore_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_packaging_materials_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_packaging_recycling_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_packaging_shapes_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_photographers_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_pnns_groups1tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_pnns_groups2tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_popularity_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_purchase_places_tag" cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_unknown_nutrients_tag" cascade;',
+    );
+
+    this.addSql('drop table if exists "query"."product_weighers_tag" cascade;');
+  }
+}

--- a/src/migrations/Migration20231216175810.ts
+++ b/src/migrations/Migration20231216175810.ts
@@ -1,0 +1,35 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231216175810 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "query"."product_periods_after_opening_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_periods_after_opening_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_periods_after_opening_tag_value_index" on "query"."product_periods_after_opening_tag" ("value");',
+    );
+
+    this.addSql(
+      'alter table "query"."product_periods_after_opening_tag" add constraint "product_periods_after_opening_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql('drop table if exists "query"."product_owners_tag" cascade;');
+  }
+
+  async down(): Promise<void> {
+    this.addSql(
+      'create table "query"."product_owners_tag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_owners_tag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_owners_tag_value_index" on "query"."product_owners_tag" ("value");',
+    );
+
+    this.addSql(
+      'alter table "query"."product_owners_tag" add constraint "product_owners_tag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+
+    this.addSql(
+      'drop table if exists "query"."product_periods_after_opening_tag" cascade;',
+    );
+  }
+}

--- a/src/migrations/Migration20231218145009.ts
+++ b/src/migrations/Migration20231218145009.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231218145009 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'alter table "query"."settings" add column "last_message_id" text null;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql(
+      'alter table "query"."settings" drop column "last_message_id";',
+    );
+  }
+}

--- a/src/migrations/Migration20231219113721.ts
+++ b/src/migrations/Migration20231219113721.ts
@@ -1,0 +1,22 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20231219113721 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "query"."product_ingredients_ntag" ("product_id" uuid not null, "value" text not null, "obsolete" boolean not null default false, constraint "product_ingredients_ntag_pkey" primary key ("product_id", "value"));',
+    );
+    this.addSql(
+      'create index "product_ingredients_ntag_value_index" on "query"."product_ingredients_ntag" ("value");',
+    );
+
+    this.addSql(
+      'alter table "query"."product_ingredients_ntag" add constraint "product_ingredients_ntag_product_id_foreign" foreign key ("product_id") references "query"."product" ("id") on update cascade on delete cascade;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql(
+      'drop table if exists "query"."product_ingredients_ntag" cascade;',
+    );
+  }
+}

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -1,3 +1,4 @@
+import { MikroORM } from '@mikro-orm/core';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 
 export default async function () {
@@ -8,8 +9,12 @@ export default async function () {
   process.env.POSTGRES_USER = container.getUsername();
   process.env.POSTGRES_PASSWORD = container.getPassword();
 
-  // Tried running migrations here but get this error: https://github.com/mikro-orm/mikro-orm/discussions/3795
-  // Removing jest.mock calls didn't help
+  // Don't import the MikroORM config at start as need the env vars to be set
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const config = require('../src/mikro-orm.config').default;
+  const orm = await MikroORM.init({ ...config, logger: () => null });
+  await orm.getMigrator().up();
+  await orm.close();
 
   globalThis.__PGCONTAINER__ = container;
 }

--- a/test/test.helper.ts
+++ b/test/test.helper.ts
@@ -14,25 +14,9 @@ export async function createTestingModule(
   const app = await Test.createTestingModule({
     imports: imports,
   }).compile();
-
-  const orm = app.get(MikroORM);
-
-  // Code here took a lot of attempts to get right
-  // If just do migrations without constraints then they can interfere with each other
-  // Tried doing migraitons in the global-setup script but that doesn't work due to a Jest issue
-  const connection = orm.em.getConnection();
-  try {
-    await connection.execute(
-      `CREATE TABLE if not exists lock_table(id int4 NOT NULL)`,
-    );
-  } catch (e) {}
-  await connection.execute('BEGIN');
-  await connection.execute(`LOCK TABLE lock_table`);
-  await orm.getMigrator().up({ transaction: orm.em.getTransactionContext() });
-  await connection.execute(`COMMIT`);
-
   await app.init();
 
+  const orm = app.get(MikroORM);
   try {
     await RequestContext.createAsync(orm.em, async () => {
       await callback(app);

--- a/test/test.helper.ts
+++ b/test/test.helper.ts
@@ -31,6 +31,8 @@ export async function createTestingModule(
   await orm.getMigrator().up({ transaction: orm.em.getTransactionContext() });
   await connection.execute(`COMMIT`);
 
+  await app.init();
+
   try {
     await RequestContext.createAsync(orm.em, async () => {
       await callback(app);
@@ -40,5 +42,6 @@ export async function createTestingModule(
     throw e;
   } finally {
     await orm.close();
+    await app.close();
   }
 }


### PR DESCRIPTION
This contains a number of changes:

- Moved to JSON as this is faster than JSONB for imports and we don't query the JSON data much
- Import ingredients hierarchy into a flat table for analysis (no query APIs for this yet)
- Added support for consuming messages from the product_update Redis message stream
- Added a source to the Product table so we can see if any items are being missed by Redis
- Fix transposed tags (PO Issue [#7397](https://github.com/openfoodfacts/openfoodfacts-server/issues/9397))
- Added new tags. Issue #22
- Automatically switch the overnight import to be a full import if new tags have been added
