### PR TITLE
Avoid intermediate commits when importing from Redis

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,7 @@ POSTGRES_PORT=127.0.0.1:5512
 POSTGRES_DB=query
 POSTGRES_USER=productopener
 POSTGRES_PASSWORD=productopener
+POSTGRES_SHM_SIZE=256m
 COMMON_NET_NAME=po_default
 MONGO_URI=mongodb://localhost:27017
 #REDIS_URL=redis://localhost:6379

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -34,6 +34,7 @@ jobs:
           echo "COMMON_NET_NAME=po_webnet" >> $GITHUB_ENV
           echo "MONGO_URI=mongodb://10.1.0.200:27017" >> $GITHUB_ENV
           echo "REDIS_URL=redis://redis:6379" >> $GITHUB_ENV
+          echo "POSTGRES_SHM_SIZE=1g" >> $GITHUB_ENV
       - name: Set various variable for production deployment
         if: matrix.env == 'off-query-org'
         run: |
@@ -46,6 +47,7 @@ jobs:
           # mongodb and redis (through stunnel)
           echo "MONGO_URI=mongodb://10.1.0.102:27017" >> $GITHUB_ENV
           echo "REDIS_URL=redis://10.1.0.122:6379" >> $GITHUB_ENV
+          echo "POSTGRES_SHM_SIZE=256m" >> $GITHUB_ENV
       - name: Wait for container build workflow
         uses: tomchv/wait-my-workflow@v1.1.0
         id: wait-build
@@ -124,6 +126,7 @@ jobs:
             echo "COMMON_NET_NAME=${{ env.COMMON_NET_NAME }}" >> .env
             echo "MONGO_URI=${{ env.MONGO_URI }}" >> .env
             echo "REDIS_URL=${{ env.REDIS_URL }}" >> .env
+            echo "POSTGRES_SHM_SIZE=${{ env.POSTGRES_SHM_SIZE }}" >> .env
             echo "LOG_LEVEL=log" >> .env
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
       - POSTGRES_DB
-    shm_size: 256m
+    shm_size: ${POSTGRES_SHM_SIZE}
     volumes:
       - dbdata:/var/lib/postgresql/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
       - POSTGRES_DB
+    shm_size: 256m
     volumes:
       - dbdata:/var/lib/postgresql/data
     networks:

--- a/src/domain/services/import.service.spec.ts
+++ b/src/domain/services/import.service.spec.ts
@@ -1,6 +1,6 @@
 import { DomainModule } from '../domain.module';
 import { ImportService } from './import.service';
-import { EntityManager } from '@mikro-orm/core';
+import { EntityManager } from '@mikro-orm/postgresql';
 import { Product } from '../entities/product';
 import { ProductIngredientsTag } from '../entities/product-tags';
 import { createTestingModule, randomCode } from '../../../test/test.helper';
@@ -351,7 +351,7 @@ describe('ProductTag', () => {
 });
 
 describe('importWithFilter', () => {
-  it.only('should not get an error with concurrent imports', async () => {
+  it('should not get an error with concurrent imports', async () => {
     await createTestingModule([DomainModule], async (app) => {
       const importService = app.get(ImportService);
 

--- a/src/domain/services/import.service.ts
+++ b/src/domain/services/import.service.ts
@@ -131,7 +131,7 @@ export class ImportService {
     await client.close();
 
     // Tags are popualted using raw SQL from the data field
-    await this.updateTags(updateId, fullImport);
+    await this.updateTags(updateId, fullImport, source);
 
     // If doing a full import delete all products that weren't updated
     if (fullImport) {
@@ -236,14 +236,20 @@ export class ImportService {
    * SQL is then run to insert this into the individual tag tables.
    * This was found to be quicker than using ORM functionality
    */
-  async updateTags(updateId: string, fullImport = false) {
+  async updateTags(
+    updateId: string,
+    fullImport = false,
+    source = ProductSource.FULL_LOAD,
+  ) {
+    const autoCommit = source !== ProductSource.EVENT;
+
     this.logger.debug(`Updating tags for updateId: ${updateId}`);
 
     const connection = this.em.getConnection();
 
     // Fix ingredients
     let logText = `Updated ingredients`;
-    await connection.execute('begin');
+    if (autoCommit) await connection.execute('begin');
     const deleted = await connection.execute(
       `delete from product_ingredient 
     where product_id in (select id from product 
@@ -329,7 +335,7 @@ export class ImportService {
       affectedRows = results['affectedRows'];
       logText += ` > ${affectedRows}`;
     }
-    await connection.execute('commit');
+    if (autoCommit) await connection.execute('commit');
     this.logger.debug(logText + ' rows');
 
     for (const [tag, entity] of Object.entries(ProductTagMap.MAPPED_TAGS)) {
@@ -337,7 +343,7 @@ export class ImportService {
       // Get the underlying table name for the entity
       const tableName = this.em.getMetadata(entity).tableName;
 
-      await connection.execute('begin');
+      if (autoCommit) await connection.execute('begin');
 
       // Delete existing tags for products that were imorted on this run
       const deleted = await connection.execute(
@@ -360,7 +366,7 @@ export class ImportService {
       );
 
       // Commit after each tag to minimise server snapshot size
-      await connection.execute('commit');
+      if (autoCommit) await connection.execute('commit');
 
       // If this is a full load we can flag the tag as now available for query
       if (fullImport) {

--- a/src/domain/services/import.service.ts
+++ b/src/domain/services/import.service.ts
@@ -241,7 +241,8 @@ export class ImportService {
     fullImport = false,
     source = ProductSource.FULL_LOAD,
   ) {
-    const autoCommit = source !== ProductSource.EVENT;
+    // Commit after each tag for bulk (non-Redis) loads to minimise server snapshot size
+    const commitPerTag = source !== ProductSource.EVENT;
 
     this.logger.debug(`Updating tags for updateId: ${updateId}`);
 
@@ -249,7 +250,7 @@ export class ImportService {
 
     // Fix ingredients
     let logText = `Updated ingredients`;
-    if (autoCommit) await connection.execute('begin');
+    if (commitPerTag) await connection.execute('begin');
     const deleted = await connection.execute(
       `delete from product_ingredient 
     where product_id in (select id from product 
@@ -335,7 +336,7 @@ export class ImportService {
       affectedRows = results['affectedRows'];
       logText += ` > ${affectedRows}`;
     }
-    if (autoCommit) await connection.execute('commit');
+    if (commitPerTag) await connection.execute('commit');
     this.logger.debug(logText + ' rows');
 
     for (const [tag, entity] of Object.entries(ProductTagMap.MAPPED_TAGS)) {
@@ -343,7 +344,7 @@ export class ImportService {
       // Get the underlying table name for the entity
       const tableName = this.em.getMetadata(entity).tableName;
 
-      if (autoCommit) await connection.execute('begin');
+      if (commitPerTag) await connection.execute('begin');
 
       // Delete existing tags for products that were imorted on this run
       const deleted = await connection.execute(
@@ -365,8 +366,7 @@ export class ImportService {
         'run',
       );
 
-      // Commit after each tag to minimise server snapshot size
-      if (autoCommit) await connection.execute('commit');
+      if (commitPerTag) await connection.execute('commit');
 
       // If this is a full load we can flag the tag as now available for query
       if (fullImport) {

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -7,12 +7,15 @@ import {
   defineConfig,
 } from '@mikro-orm/core';
 import { SCHEMA } from './constants';
+import { Logger } from '@nestjs/common';
 
 class DateTimeNtzType extends DateTimeType {
   getColumnType(): string {
     return 'timestamp';
   }
 }
+
+const logger = new Logger('MikroOrm');
 
 export default defineConfig({
   entities: ['./dist/domain/entities'],
@@ -46,6 +49,16 @@ export default defineConfig({
   migrations: {
     path: 'dist/migrations',
     pathTs: 'src/migrations',
+  },
+  pool: {
+    afterCreate: function (conn: any, done: any) {
+      conn.query('select 1 as result', function (err) {
+        conn.on('notice', function (msg) {
+          logger.error('Notice from PostgreSQL: ' + msg.message);
+        });
+        done(err, conn);
+      });
+    },
   },
   // Uncomment the below and 'app.useLogger(new Logger());' to the test to see Mikro-ORM logs
   // debug: ['query', 'query-params'],

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
   },
   pool: {
     afterCreate: function (conn: any, done: any) {
+      // issue a query to verify SQL connection is working
       conn.query('select 1 as result', function (err) {
         conn.on('notice', function (msg) {
           logger.error('Notice from PostgreSQL: ' + msg.message);

--- a/test/test.helper.ts
+++ b/test/test.helper.ts
@@ -1,5 +1,6 @@
 import { MikroORM, RequestContext } from '@mikro-orm/core';
 import { logger } from '@mikro-orm/nestjs';
+import { ConsoleLogger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { randomBytes } from 'crypto';
 
@@ -7,20 +8,41 @@ export function randomCode() {
   return 'TEST-' + randomBytes(20).toString('base64');
 }
 
+class TestLogger extends ConsoleLogger {
+  errors = new Array<string>();
+  expectedErrors = 0;
+  constructor() {
+    super();
+    this.setLogLevels(['error']);
+  }
+  error(message: string, ...rest: any[]) {
+    this.errors.push(message);
+    if (this.errors.length > this.expectedErrors) {
+      super.error(message, ...rest);
+    }
+  }
+  assertExpectedErrors() {
+    expect(this.errors).toHaveLength(this.expectedErrors);
+  }
+}
+
 export async function createTestingModule(
   imports: any[],
-  callback: { (app: TestingModule): Promise<void> },
+  callback: { (app: TestingModule, logger: TestLogger): Promise<void> },
 ) {
+  const testLogger = new TestLogger();
   const app = await Test.createTestingModule({
     imports: imports,
   }).compile();
+  app.useLogger(testLogger);
   await app.init();
 
   const orm = app.get(MikroORM);
   try {
     await RequestContext.createAsync(orm.em, async () => {
-      await callback(app);
+      await callback(app, testLogger);
     });
+    testLogger.assertExpectedErrors();
   } catch (e) {
     (e.errors ?? [e]).map((e) => logger.error(e.message, e.stack));
     throw e;


### PR DESCRIPTION
### What
- When importing from Redis volumes are small so don't need intermediate commits

### Fixes bug(s)
- #43

