### PR TITLE
fix(ci): resolve Docker image push permission issues in GitHub Actions

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,4 +1,4 @@
-name: Docker Image Build CI
+name: Docker Image CI
 
 on:
   push:
@@ -9,55 +9,84 @@ on:
       - v*.*.*
   pull_request:
 
+permissions:
+  packages: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
+      - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.6.0
+          version: v0.10.0
           buildkitd-flags: --debug
 
-      - name: Use Node.js
+      - name: Set Up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - run: npm ci
+      - name: Install Dependencies
+        run: npm ci
 
-      - run: npm test
+      - name: Run Tests
+        run: npm test
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker meta
+      - name: Generate Docker Metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           tags: |
             type=semver,pattern={{version}}
             type=ref,event=pr
             type=ref,event=branch
             type=sha,format=long
 
-      - name: Build and push
+      - name: Build and Push (Non-PR Events)
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           file: Dockerfile
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build Only (PR from Forks)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          file: Dockerfile
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and Push (PR from Same Repo)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          file: Dockerfile
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:buildcache,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -5,7 +5,7 @@ on:
     types:
       - opened
       - edited
-      - transfered
+      - transferred
 
 jobs:
   add-to-project:


### PR DESCRIPTION
**Signed-off-by:** Areeb Ahmed [areebshariff@acm.org](mailto:areebshariff@acm.org)

## Summary of Changes
**Fixes:** #123

- Skip image pushing for PR builds from forks 
- Add workflow-level permissions for packages and contents
- Update Buildx to v0.10.0 for attestation support (See below screenshot)
- Use explicit repository references for reliable image naming
- Also fixed a typo in `github-projects.yml`

<img width="866" alt="{1FC20099-6E86-4FB9-B2CC-76C6554075D3}" src="https://github.com/user-attachments/assets/1f7dd1ac-efba-4a85-a60d-21fc3dc7dbf2" />
