### PR TITLE
fix: Only create product_country records from scans if there is a corresponding countries_tag

### DIFF
--- a/query/migrations/Migration20250609175700.py
+++ b/query/migrations/Migration20250609175700.py
@@ -1,0 +1,5 @@
+from ..tables import product_country
+
+
+async def up(transaction):
+    await product_country.delete_product_countries_with_no_tag(transaction)

--- a/query/services/ingestion_test.py
+++ b/query/services/ingestion_test.py
@@ -73,6 +73,10 @@ async def test_import_from_mongo_should_import_a_new_product_update_existing_pro
         )
         world = await get_country(transaction, "en:world")
         await create_product_country(transaction, product_existing, world, 10, 100)
+        
+        # Create an existing product_country for a countries_tag not included in the import
+        uk = await get_country(transaction, "en:united-kingdom")
+        await create_product_country(transaction, product_existing, uk, 2, 10)
 
         product_unchanged = await create_product(
             transaction, code=random_code(), process_id=0
@@ -120,7 +124,7 @@ async def test_import_from_mongo_should_import_a_new_product_update_existing_pro
         assert any(i for i in ingredients_existing if i["value"] == "old_ingredient")
         assert any(i for i in ingredients_existing if i["value"] == "new_ingredient")
 
-        # should create an entry for each country plus world
+        # should create an entry for each country plus world but not UK
         countries_existing = await get_product_countries(transaction, product_existing)
         assert len(countries_existing) == 3
         existing_world = next(

--- a/query/services/query_count_test.py
+++ b/query/services/query_count_test.py
@@ -127,6 +127,13 @@ async def create_test_tags(transaction):
 
     country = await create_country(transaction, tag=random_code(), code=random_code())
 
+    # Need to create the country tag for each product as otherwise product_countries won't be created
+    await create_tag(transaction, "countries_tags", product1, country['tag'])
+    await create_tag(transaction, "countries_tags", product2, country['tag'])
+    await create_tag(transaction, "countries_tags", product3, country['tag'])
+    await create_tag(transaction, "countries_tags", product4, country['tag'])
+    
+
     return TagValues(
         origin_value=origin_value,
         amino_value=amino_value,

--- a/query/tables/product_country.py
+++ b/query/tables/product_country.py
@@ -48,6 +48,16 @@ async def fix_index(transaction):
     )
 
 
+# Migration script. We were previously creating a product country entry where there was no tag
+async def delete_product_countries_with_no_tag(transaction):
+    await transaction.execute( """DELETE FROM product_country pc
+            USING country c
+            WHERE c.id = pc.country_id 
+            AND c.code <> 'world'
+            AND NOT EXISTS (SELECT * FROM product_countries_tag pct WHERE pct.product_id = pc.product_id AND pct.value = c.tag)
+        """
+    )
+    
 async def create_product_country(
     transaction, product, country, recent_scans, total_scans
 ):
@@ -85,15 +95,34 @@ async def fixup_product_countries(transaction, obsolete):
             ON CONFLICT (product_id, country_id) DO NOTHING""",
         obsolete,
     )
+    # Delete any product countries where there is no tag
+    await transaction.execute(
+        """DELETE FROM product_country pc
+            USING product_temp pt,
+                country c
+            WHERE pc.product_id = pt.id
+            AND c.id = pc.country_id
+            AND c.code <> 'world'
+            AND NOT EXISTS (SELECT * FROM product_countries_tag pct WHERE pct.product_id = pc.product_id AND pct.value = c.tag)
+        """
+    )
 
 
 async def fixup_product_countries_for_products(transaction, ids_updated):
+    # Note we only create a product_country entry if there is a corresponding product_countries_tag
     await transaction.execute(
         """insert into product_country (product_id, obsolete, country_id, recent_scans, total_scans)
-            select product_id, p.obsolete, country_id, sum(CASE WHEN year = $3 THEN unique_scans ELSE 0 END), sum(CASE WHEN year >= $2 THEN unique_scans ELSE 0 END)
-            from product_scans_by_country
-            join product p on p.id = product_id
-            where product_id = ANY($1)
+            select s.product_id,
+                p.obsolete,
+                s.country_id,
+                sum(CASE WHEN s.year = $3 THEN s.unique_scans ELSE 0 END),
+                sum(CASE WHEN s.year >= $2 THEN unique_scans ELSE 0 END)
+            from product_scans_by_country s
+            join product p on p.id = s.product_id
+            join country c on c.id = s.country_id
+            where s.product_id = ANY($1) and (
+                c.code = 'world' or
+                exists (select * from product_countries_tag t where t.product_id = s.product_id and t.value = c.tag))
             group by product_id, p.obsolete, country_id
             on conflict (product_id, country_id)
             do update set recent_scans = excluded.recent_scans, total_scans = excluded.total_scans, obsolete = excluded.obsolete""",
@@ -102,4 +131,3 @@ async def fixup_product_countries_for_products(transaction, ids_updated):
         CURRENT_YEAR,
     )
 
-    # Note that the product_counties_tag table and product_country table could potentially get of of sync a bit, but don't worry about this for now


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
- Make sure we only create a product_country if there is a corresponding product countries_tag

### Fixes bug(s)
- #134
