### PR TITLE
fix: Always cast integers as numeric to avoid issues with dot zeros

### DIFF
--- a/query/tables/product.py
+++ b/query/tables/product.py
@@ -147,6 +147,8 @@ async def update_products_from_staging(
     transaction: Connection, log, obsolete, process_id, source
 ):
     """Apply updates to products from the product_temp table. Assumes that a minimal product record has already been created"""
+    
+    # Note we cast as numeric rather than int in the SQL below as casting something like "2.0" as an int will fail
     product_results = await transaction.execute(
         f"""
       update product
@@ -157,19 +159,19 @@ async def update_products_from_staging(
         ingredients_count = (tp.data->>'ingredients_n')::numeric,
         ingredients_without_ciqual_codes_count = (tp.data->>'ingredients_without_ciqual_codes_n')::numeric,
         last_updated = tp.last_updated,
-        created = to_timestamp((tp.data->>'created_t')::int),
-        last_modified = to_timestamp((tp.data->>'last_modified_t')::int),
+        created = to_timestamp((tp.data->>'created_t')::numeric),
+        last_modified = to_timestamp((tp.data->>'last_modified_t')::numeric),
         completeness = (tp.data->>'completeness')::double precision,
-        nutriscore = (tp.data->>'nutriscore_score')::int,
-        environmental_score = (tp.data->>'environmental_score_score')::int,
-        ingredients_from_palm_oil_count = (tp.data->>'ingredients_from_palm_oil_n')::int,
-        ingredients_that_may_be_from_palm_oil_count = (tp.data->>'ingredients_that_may_be_from_palm_oil_n')::int,
-        additives_count = (tp.data->>'additives_n')::int,
-        ingredients_from_or_that_may_be_from_palm_oil_count = (tp.data->>'ingredients_from_or_that_may_be_from_palm_oil_n')::int,
+        nutriscore = (tp.data->>'nutriscore_score')::numeric,
+        environmental_score = (tp.data->>'environmental_score_score')::numeric,
+        ingredients_from_palm_oil_count = (tp.data->>'ingredients_from_palm_oil_n')::numeric,
+        ingredients_that_may_be_from_palm_oil_count = (tp.data->>'ingredients_that_may_be_from_palm_oil_n')::numeric,
+        additives_count = (tp.data->>'additives_n')::numeric,
+        ingredients_from_or_that_may_be_from_palm_oil_count = (tp.data->>'ingredients_from_or_that_may_be_from_palm_oil_n')::numeric,
         process_id = $2,
         last_processed = $3,
         source = $4,
-        revision = (tp.data->>'rev')::int
+        revision = (tp.data->>'rev')::numeric
       from product_temp tp
       where product.id = tp.id""",
         obsolete,

--- a/query/tables/product_country.py
+++ b/query/tables/product_country.py
@@ -137,6 +137,6 @@ async def fixup_product_countries_for_products(transaction, ids_updated):
 async def delete_product_countries(transaction, product_ids):
     """Soft delete by setting the obsolete flag to null"""
     await transaction.execute(
-        f"UPDATE product_country SET obsolete = NULL WHERE product_id = ANY($1::int[])",
+        f"UPDATE product_country SET obsolete = NULL WHERE product_id = ANY($1::numeric[])",
         product_ids,
     )

--- a/query/tables/product_ingredient.py
+++ b/query/tables/product_ingredient.py
@@ -127,6 +127,6 @@ async def create_ingredients_from_staging(transaction: Connection, log, obsolete
 
 async def delete_ingredients(transaction, product_ids):
     await transaction.execute(
-        f"UPDATE product_ingredient SET obsolete = NULL WHERE product_id = ANY($1::int[])",
+        f"UPDATE product_ingredient SET obsolete = NULL WHERE product_id = ANY($1::numeric[])",
         product_ids,
     )

--- a/query/tables/product_scans_by_country.py
+++ b/query/tables/product_scans_by_country.py
@@ -44,7 +44,7 @@ async def create_scans(transaction, scans: ProductScans):
         # As mentioned above, need to cast ints in the SQL because of the source values clause
         await transaction.executemany(
             """insert into product_scans_by_country (product_id, year, country_id, unique_scans) 
-            select product.id, source.year::int, country.id, source.scans::int 
+            select product.id, source.year::numeric, country.id, source.scans::numeric 
             from (values ($1, $2, $3, $4)) as source (code, year, country, scans)
             join product on product.code = source.code
             join country on country.code = source.country

--- a/query/tables/product_tags.py
+++ b/query/tables/product_tags.py
@@ -132,7 +132,7 @@ async def delete_tags(transaction, product_ids):
     """Soft deletes tags for the specified products"""
     for tag_table in TAG_TABLES.values():
         await transaction.execute(
-            f"UPDATE {tag_table} SET obsolete = NULL WHERE product_id = ANY($1::int[])",
+            f"UPDATE {tag_table} SET obsolete = NULL WHERE product_id = ANY($1::numeric[])",
             product_ids,
         )
 

--- a/query/tables/product_update.py
+++ b/query/tables/product_update.py
@@ -41,7 +41,7 @@ async def create_updates_from_events(transaction: Connection, event_ids: List[in
         event_id)
       SELECT 
       	p.id,
-        coalesce((pe.message->>'rev')::int, p.revision),
+        coalesce((pe.message->>'rev')::numeric, p.revision),
         date(pe.updated_at at time zone 'UTC') updated_day,
         update_type.id,
         contributor.id,


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
- Get error during migration casting "30.0" as an int

