### PR TITLE
fix: Cope with combination of root-level and $and filter

### DIFF
--- a/query/services/query.py
+++ b/query/services/query.py
@@ -246,11 +246,15 @@ def append_sql_fragments(
     query directly to MongoDB instead.
     The parent_id_column determines how inner queries join to the product id of the parent table,
     which is assumed to have an alias of 'p'"""
-    fragments = filter.qualify_and or [filter]
+    # Merge the top level with any $and criteria
+    fragments = [filter] + (filter.qualify_and or [])
     for fragment in fragments:
         for tag, value in fragment.model_dump(
             exclude_defaults=True, by_alias=True
         ).items():
+            # Skip qualify_and as already merged above
+            if tag == "$and":
+                continue
             product_column_name = get_product_column_for_field(tag, loaded_tags)
             if not product_column_name:
                 check_tag_is_loaded(tag, loaded_tags)

--- a/query/services/query_count_test.py
+++ b/query/services/query_count_test.py
@@ -10,7 +10,7 @@ from query.tables.nutrient import create_nutrient
 from query.tables.product_nutrient import NUTRIENT_TAG, create_product_nutrient
 
 from ..database import get_transaction
-from ..models.query import Filter, Qualify
+from ..models.query import Filter, Fragment, Qualify
 from ..services import query
 from ..tables.country import create_country
 from ..tables.product import PRODUCT_SCANS_TAG, create_product
@@ -415,3 +415,16 @@ async def test_nutrient_filter():
         Filter(**{f"{NUTRIENT_TAG}.{tags.nutrient_tag}_100g": Qualify(qualify_lte=0.2)})
     )
     assert results == 2
+
+
+async def test_can_combine_root_filter_with_and():
+    async with get_transaction() as transaction:
+        tags = await create_test_tags(transaction)
+
+    response = await query.count(
+        Filter(
+            nucleotides_tags=tags.neucleotide_value,
+            qualify_and=[Fragment(amino_acids_tags=tags.amino_value),Fragment(amino_acids_tags=tags.amino_value2)]
+        )
+    )
+    assert response == 0


### PR DESCRIPTION
### What
- Ensure filters at the root and inside an $and are both respected

### Fixes bug(s)
- #164
