### PR TITLE
fix: Dependabot needs patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,8 @@ updates:
       interval: "weekly"
     groups:
       deps-github-actions:
-        dependency-type: development
+        patterns:
+          - "*"
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     commit-message:
@@ -25,5 +26,9 @@ updates:
     groups:
       deps-production:
         dependency-type: production
+        patterns:
+          - "*"
       deps-dev:
         dependency-type: development
+        patterns:
+          - "*"


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
- Skips group if there are no patterns
