### PR TITLE
fix: Cater for invalid rev values

### DIFF
--- a/query/events_test.py
+++ b/query/events_test.py
@@ -285,6 +285,39 @@ async def test_messages_received_strips_nulls(import_with_filter: Mock):
         )
 
 
+@patch.object(event, "import_with_filter")
+async def test_messages_copes_with_invalid_revision(import_with_filter: Mock):
+    async with get_transaction() as transaction:
+        timestamp = math.floor(time.time())
+        code = random_code()
+        test_message = {
+            "timestamp": timestamp,
+            "code": code,
+            "rev": "",
+            "flavor": "off",
+            "product_type": "food",
+            "user_id": "test_user",
+            "action": "updated",
+        }
+
+        message_id = f"{timestamp}-{code}"
+        await messages_received(
+            transaction, [["test-stream", [[message_id, test_message]]]]
+        )
+
+        assert import_with_filter.called
+        event = await transaction.fetchrow(
+            "select * from product_update_event where message_id = $1",
+            message_id,
+        )
+        assert event
+        product_update = await transaction.fetchrow(
+            "select * from product_update where event_id = $1",
+            event["id"],
+        )
+        assert product_update
+
+
 @patch.object(events, "process_events")
 async def test_copes_with_missing_fields(process_events: Mock):
     async with get_transaction() as transaction:

--- a/query/services/ingestion_test.py
+++ b/query/services/ingestion_test.py
@@ -65,6 +65,7 @@ def get_test_products():
                             "value": random.uniform(100, 0.000001),
                         },
                         "invalid": {"value": "100g"},
+                        "fat": {"value": "30"},
                     }
                 }
             },
@@ -223,7 +224,7 @@ async def test_import_from_mongo_should_import_a_new_product_update_existing_pro
         existing_product_nutrients = await get_product_nutrients(
             transaction, product_existing
         )
-        assert len(existing_product_nutrients) == 2
+        assert len(existing_product_nutrients) == 3
         found_random_product_nutrient = [
             item
             for item in existing_product_nutrients
@@ -244,6 +245,17 @@ async def test_import_from_mongo_should_import_a_new_product_update_existing_pro
         ]
         assert found_carbohydrate
         assert found_carbohydrate[0]["value"] == 21
+        
+        # Should cater for nutrients supplied in quotes
+        fat_nutrient = await get_nutrient(transaction, "fat")
+        found_fat = [
+            item
+            for item in existing_product_nutrients
+            if item["nutrient_id"] == fat_nutrient["id"]
+        ]
+        assert found_fat
+        assert found_fat[0]["value"] == 30
+        
 
 
 @patch.object(ingestion, "find_products")

--- a/query/tables/product_nutrient.py
+++ b/query/tables/product_nutrient.py
@@ -63,7 +63,7 @@ async def create_product_nutrients_from_staging(transaction: Connection, log):
         and right(source.key, 5) = '_100g'
         and right(source.key, 13) != 'prepared_100g'
         and pg_input_is_valid(source.value::text, 'double precision')
-        union select pt.id, n.id, (source.value->'value')::double precision
+        union select pt.id, n.id, (source.value->>'value')::double precision
         from product_temp pt
         cross join jsonb_each(data->'nutrition'->'aggregated_set'->'nutrients') source
         join nutrient n on n.tag = source.key

--- a/query/tables/product_update.py
+++ b/query/tables/product_update.py
@@ -43,7 +43,7 @@ async def create_updates_from_events(transaction: Connection, event_ids: List[in
         event_id)
       SELECT 
       	p.id,
-        coalesce((pe.message->>'rev')::numeric, p.revision),
+        COALESCE(CASE WHEN pg_input_is_valid(pe.message->>'rev', 'numeric') THEN (pe.message->>'rev')::numeric ELSE p.revision END, 0),
         date(pe.updated_at at time zone 'UTC') updated_day,
         update_type.id,
         contributor.id,


### PR DESCRIPTION
### What
- Was getting an error where the rev in the message was an empty string
- Also fixed an issue where wasn't coping with nutrient values supplied as text (in quotes)
