### PR TITLE
chore: Switch back to absolute imports

### DIFF
--- a/query/conftest.py
+++ b/query/conftest.py
@@ -5,9 +5,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from testcontainers.postgres import PostgresContainer
 from testcontainers.redis import RedisContainer
 
-from .config import config_settings
-from .database import create_connection_pool
-from .migrator import migrate_database
+from query.config import config_settings
+from query.database import create_connection_pool
+from query.migrator import migrate_database
 
 
 # Don't prefix with "Test" as otherwise pytest thinks this is a test class

--- a/query/database.py
+++ b/query/database.py
@@ -7,7 +7,7 @@ from typing import Any, AsyncGenerator
 
 import asyncpg
 
-from .config import config_settings
+from query.config import config_settings
 
 logger = logging.getLogger(__name__)
 

--- a/query/database_test.py
+++ b/query/database_test.py
@@ -3,9 +3,9 @@ from datetime import datetime, timezone
 import pytest
 from asyncpg import PostgresError
 
-from .database import create_record, get_rows_affected, get_transaction, strip_nuls
-from .tables import product_temp
-from .test_helper import random_code
+from query.database import create_record, get_rows_affected, get_transaction, strip_nuls
+from query.tables import product_temp
+from query.test_helper import random_code
 
 
 async def test_rows_affected_returned_correctly():

--- a/query/events.py
+++ b/query/events.py
@@ -9,11 +9,11 @@ from typing import Any, AsyncGenerator, Dict, List
 
 import redis.asyncio as redis
 
-from .config import config_settings
-from .database import get_transaction, strip_nuls
-from .models.domain_event import DomainEvent
-from .services.event import STREAM_NAME, process_events
-from .tables.settings import (
+from query.config import config_settings
+from query.database import get_transaction, strip_nuls
+from query.models.domain_event import DomainEvent
+from query.services.event import STREAM_NAME, process_events
+from query.tables.settings import (
     apply_pre_migration_message_id,
     get_last_message_id,
     set_last_message_id,

--- a/query/events_test.py
+++ b/query/events_test.py
@@ -9,11 +9,9 @@ import pytest
 from redis.asyncio import Redis, ResponseError, from_url
 from testcontainers.redis import RedisContainer
 
-from query.services import event
-
-from . import events
-from .database import get_transaction
-from .events import (
+from query import events
+from query.database import get_transaction
+from query.events import (
     STREAM_NAME,
     get_message_timestamp,
     get_retry_interval,
@@ -21,7 +19,8 @@ from .events import (
     redis_client,
     redis_listener,
 )
-from .test_helper import random_code
+from query.services import event
+from query.test_helper import random_code
 
 logger = logging.getLogger(__name__)
 

--- a/query/main.py
+++ b/query/main.py
@@ -5,7 +5,7 @@ import sys
 
 import uvicorn
 
-from .migrator import migrate_database
+from query.migrator import migrate_database
 
 if __name__ == "__main__":
     # Check that migrations have been run.

--- a/query/migrations/Migration20250614092300.py
+++ b/query/migrations/Migration20250614092300.py
@@ -1,4 +1,4 @@
-from ..tables import (
+from query.tables import (
     contributor,
     country,
     loaded_tag,
@@ -12,7 +12,7 @@ from ..tables import (
     settings,
     update_type,
 )
-from ..views import product_updates_by_owner, views
+from query.views import product_updates_by_owner, views
 
 
 async def up(transaction):

--- a/query/migrator.py
+++ b/query/migrator.py
@@ -7,10 +7,9 @@ from importlib import import_module
 
 from asyncpg import Connection
 
+from query.config import config_settings
+from query.database import get_transaction
 from query.tables.settings import set_pre_migration_message_id
-
-from .config import config_settings
-from .database import get_transaction
 
 MIGRATIONS_TABLE = "mikro_orm_migrations"
 MIGRATIONS_FOLDER = "query/migrations"

--- a/query/models/query.py
+++ b/query/models/query.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Dict, List, Tuple
 
 from pydantic import BaseModel, Field, create_model
 
-from ..tables.product import product_fields
+from query.tables.product import product_fields
 
 NoValues = Annotated[
     Tuple[None, List[None]],

--- a/query/mongodb.py
+++ b/query/mongodb.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 from pymongo import AsyncMongoClient
 
+from query.config import config_settings
 from query.tables.collection_type import (
     BEAUTY,
     BEAUTY_OBSOLETE,
@@ -16,8 +17,6 @@ from query.tables.collection_type import (
     PRODUCT,
     PRODUCT_OBSOLETE,
 )
-
-from .config import config_settings
 
 # Limit the MongoDB logging as it is a bit verbose
 logging.getLogger("pymongo").setLevel(logging.WARNING)

--- a/query/routes.py
+++ b/query/routes.py
@@ -12,25 +12,24 @@ from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
-from query.services.event import import_events
-
-from .config import config_settings
-from .database import database_lifespan
-from .events import redis_lifespan
-from .models.health import Health
-from .models.query import (
+from query.config import config_settings
+from query.database import database_lifespan
+from query.events import redis_lifespan
+from query.models.health import Health
+from query.models.query import (
     AggregateCountResult,
     AggregateResult,
     Filter,
     FindQuery,
     Stage,
 )
-from .models.scan import ProductScans
-from .scheduler import scheduler_lifespan
-from .services import ingestion, query
-from .services.health import check_health
-from .services.scan import import_scans
-from .tables.collection_type import ProductType
+from query.models.scan import ProductScans
+from query.scheduler import scheduler_lifespan
+from query.services import ingestion, query
+from query.services.event import import_events
+from query.services.health import check_health
+from query.services.scan import import_scans
+from query.tables.collection_type import ProductType
 
 logger = logging.getLogger(__name__)
 

--- a/query/routes_test.py
+++ b/query/routes_test.py
@@ -3,11 +3,10 @@ from contextlib import asynccontextmanager
 from fastapi import status
 from httpx import ASGITransport, AsyncClient
 
+from query.database import get_transaction
+from query.routes import app
+from query.services.query_count_test import create_test_tags
 from query.services.query_find_test import create_tags_and_scans
-
-from .database import get_transaction
-from .routes import app
-from .services.query_count_test import create_test_tags
 
 
 @asynccontextmanager

--- a/query/scheduler.py
+++ b/query/scheduler.py
@@ -9,11 +9,10 @@ from contextlib import contextmanager
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
+from query.database import get_transaction
+from query.events import start_redis_listener, stop_redis_listener
+from query.services.ingestion import import_from_mongo
 from query.tables.collection_type import SUPPORTED_PRODUCT_TYPES
-
-from .database import get_transaction
-from .events import start_redis_listener, stop_redis_listener
-from .services.ingestion import import_from_mongo
 
 logger = logging.getLogger(__name__)
 

--- a/query/services/event.py
+++ b/query/services/event.py
@@ -4,13 +4,12 @@ import math
 from datetime import datetime, timezone
 from typing import Dict, List
 
+from query.database import get_transaction, strip_nuls
+from query.models.domain_event import DomainEvent
+from query.models.product import Source
+from query.services.ingestion import import_with_filter
 from query.tables.collection_type import SUPPORTED_PRODUCT_TYPES
-
-from ..database import get_transaction, strip_nuls
-from ..models.domain_event import DomainEvent
-from ..models.product import Source
-from ..services.ingestion import import_with_filter
-from ..tables.product_update_event import create_events
+from query.tables.product_update_event import create_events
 
 STREAM_NAME = "product_updates"
 

--- a/query/services/event_test.py
+++ b/query/services/event_test.py
@@ -2,13 +2,13 @@ import math
 import time
 from unittest.mock import Mock, patch
 
-from ..database import get_transaction
-from ..events import STREAM_NAME
-from ..models.domain_event import DomainEvent
-from ..models.product import Source
-from ..services.event import import_events, process_events
-from ..test_helper import random_code
-from . import event
+from query.database import get_transaction
+from query.events import STREAM_NAME
+from query.models.domain_event import DomainEvent
+from query.models.product import Source
+from query.services import event
+from query.services.event import import_events, process_events
+from query.test_helper import random_code
 
 message_index = 0
 

--- a/query/services/health.py
+++ b/query/services/health.py
@@ -2,14 +2,13 @@
 
 import redis.asyncio as redis
 
+from query.config import config_settings
+from query.database import get_transaction
+from query.models.health import Health, HealthItemStatusEnum
+from query.mongodb import find_products
 from query.services.event import STREAM_NAME
 from query.tables.collection_type import FOOD, get_last_updated
 from query.tables.settings import get_last_message_id
-
-from ..config import config_settings
-from ..database import get_transaction
-from ..models.health import Health, HealthItemStatusEnum
-from ..mongodb import find_products
 
 
 async def check_health():

--- a/query/services/health_test.py
+++ b/query/services/health_test.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
-from ..models.health import HealthItemStatusEnum, HealthStatusEnum
-from ..services.health import check_health
-from ..test_helper import error_cursor, mock_cursor, patch_context_manager
-from . import health
+from query.models.health import HealthItemStatusEnum, HealthStatusEnum
+from query.services import health
+from query.services.health import check_health
+from query.test_helper import error_cursor, mock_cursor, patch_context_manager
 
 
 @patch.object(health, "find_products")

--- a/query/services/ingestion.py
+++ b/query/services/ingestion.py
@@ -9,6 +9,11 @@ import asyncpg
 from asyncpg import Connection
 from uvicorn.logging import TRACE_LOG_LEVEL
 
+from query.config import config_settings
+from query.database import get_transaction, strip_nuls
+from query.models.product import Source
+from query.mongodb import find_products
+from query.tables import product_temp
 from query.tables.collection_type import (
     COLLECTION_MAP,
     COLLECTION_NAMES,
@@ -16,18 +21,7 @@ from query.tables.collection_type import (
     get_last_updated,
     set_last_updated,
 )
-from query.tables.product_nutrient import (
-    NUTRIENT_TAG,
-    NUTRITION_TAG,
-    create_product_nutrients_from_staging,
-)
-
-from ..config import config_settings
-from ..database import get_transaction, strip_nuls
-from ..models.product import Source
-from ..mongodb import find_products
-from ..tables import product_temp
-from ..tables.product import (
+from query.tables.product import (
     PRODUCT_FIELD_COLUMNS,
     PRODUCT_TAG,
     create_minimal_product,
@@ -35,12 +29,21 @@ from ..tables.product import (
     get_minimal_product,
     update_products_from_staging,
 )
-from ..tables.product_country import fixup_product_countries
-from ..tables.product_ingredient import (
+from query.tables.product_country import fixup_product_countries
+from query.tables.product_ingredient import (
     INGREDIENTS_TAG,
     create_ingredients_from_staging,
 )
-from ..tables.product_tags import COUNTRIES_TAG, TAG_TABLES, create_tags_from_staging
+from query.tables.product_nutrient import (
+    NUTRIENT_TAG,
+    NUTRITION_TAG,
+    create_product_nutrients_from_staging,
+)
+from query.tables.product_tags import (
+    COUNTRIES_TAG,
+    TAG_TABLES,
+    create_tags_from_staging,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/query/services/ingestion_test.py
+++ b/query/services/ingestion_test.py
@@ -5,8 +5,10 @@ import time
 from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
+from query.database import get_transaction
+from query.models.product import Source
 from query.models.query import Filter
-from query.services import query
+from query.services import ingestion, query
 from query.tables.collection_type import (
     BEAUTY,
     DELETED,
@@ -16,19 +18,14 @@ from query.tables.collection_type import (
     get_last_updated,
     set_last_updated,
 )
+from query.tables.country import add_all_countries, get_country
 from query.tables.nutrient import get_nutrient
+from query.tables.product import create_product, get_product, get_product_by_id
+from query.tables.product_country import create_product_country, get_product_countries
+from query.tables.product_ingredient import get_ingredients
 from query.tables.product_nutrient import get_product_nutrients
-
-from ..database import get_transaction
-from ..models.product import Source
-from ..services import ingestion
-from ..tables.country import add_all_countries, get_country
-from ..tables.product import create_product, get_product, get_product_by_id
-from ..tables.product_country import create_product_country, get_product_countries
-from ..tables.product_ingredient import get_ingredients
-from ..tables.product_tags import create_tag, get_tags
-from ..test_helper import mock_cursor, patch_context_manager, random_code
-from . import ingestion
+from query.tables.product_tags import create_tag, get_tags
+from query.test_helper import mock_cursor, patch_context_manager, random_code
 
 
 async def test_get_process_id_is_monotonically_increasing():

--- a/query/services/query.py
+++ b/query/services/query.py
@@ -6,11 +6,8 @@ from typing import Dict, List
 from asyncpg import Connection
 from fastapi import HTTPException, status
 
-from query.tables.collection_type import COLLECTION_MAP, ProductType
-from query.tables.product_nutrient import NUTRIENT_TAG, NUTRITION_TAG
-
-from ..database import get_transaction
-from ..models.query import (
+from query.database import get_transaction
+from query.models.query import (
     AggregateCountResult,
     AggregateResult,
     Filter,
@@ -18,17 +15,19 @@ from ..models.query import (
     SortColumn,
     Stage,
 )
-from ..mongodb import find_products
-from ..tables.country import get_country
-from ..tables.loaded_tag import check_tag_is_loaded, get_loaded_tags
-from ..tables.product import (
+from query.mongodb import find_products
+from query.tables.collection_type import COLLECTION_MAP, ProductType
+from query.tables.country import get_country
+from query.tables.loaded_tag import check_tag_is_loaded, get_loaded_tags
+from query.tables.product import (
     PRODUCT_FIELD_COLUMNS,
     PRODUCT_FIELD_SCANS_COLUMNS,
     PRODUCT_SCANS_TAG,
     get_product_column_for_field,
 )
-from ..tables.product_country import PRODUCT_COUNTRY_TAG
-from ..tables.product_tags import TAG_TABLES
+from query.tables.product_country import PRODUCT_COUNTRY_TAG
+from query.tables.product_nutrient import NUTRIENT_TAG, NUTRITION_TAG
+from query.tables.product_tags import TAG_TABLES
 
 logger = logging.getLogger(__name__)
 

--- a/query/services/query_aggregate_test.py
+++ b/query/services/query_aggregate_test.py
@@ -1,12 +1,11 @@
 import pytest
 from pydantic import ValidationError
 
+from query.database import get_transaction
+from query.models.query import Filter, GroupStage, Qualify, Stage
+from query.services import query
+from query.services.query_count_test import create_test_tags
 from query.tables.product_nutrient import NUTRIENT_TAG
-
-from ..database import get_transaction
-from ..models.query import Filter, GroupStage, Qualify, Stage
-from ..services import query
-from ..services.query_count_test import create_test_tags
 
 
 async def test_group_products_with_a_tag():

--- a/query/services/query_count_test.py
+++ b/query/services/query_count_test.py
@@ -6,18 +6,16 @@ from asyncpg import Record
 from fastapi import HTTPException, status
 from pydantic import ValidationError
 
+from query.database import get_transaction
+from query.models.query import Filter, Fragment, Qualify
+from query.services import query
 from query.tables.collection_type import FOOD, FOOD_OBSOLETE, ProductType
+from query.tables.country import create_country
 from query.tables.nutrient import create_nutrient
+from query.tables.product import PRODUCT_SCANS_TAG, create_product
 from query.tables.product_nutrient import NUTRIENT_TAG, create_product_nutrient
-
-from ..database import get_transaction
-from ..models.query import Filter, Fragment, Qualify
-from ..services import query
-from ..tables.country import create_country
-from ..tables.product import PRODUCT_SCANS_TAG, create_product
-from ..tables.product_tags import create_tag
-from ..test_helper import random_code
-from . import query
+from query.tables.product_tags import create_tag
+from query.test_helper import random_code
 
 
 async def create_random_product(

--- a/query/services/query_find_test.py
+++ b/query/services/query_find_test.py
@@ -4,20 +4,17 @@ import pytest
 from fastapi import HTTPException, status
 from pydantic import ValidationError
 
-from query.services import scan
+from query.database import get_transaction
+from query.models.query import Filter, FindQuery, Fragment, Qualify, SortColumn
+from query.services import query, scan
+from query.services.query_count_test import create_test_tags
 from query.services.scan import scans_fully_loaded
 from query.tables.collection_type import FOOD_OBSOLETE
+from query.tables.country import get_country
 from query.tables.product_nutrient import NUTRIENT_TAG, NUTRITION_TAG
 from query.tables.product_scans import create_product_scan
-
-from ..database import get_transaction
-from ..models.query import Filter, FindQuery, Fragment, Qualify, SortColumn
-from ..services import query
-from ..services.query_count_test import create_test_tags
-from ..tables.country import get_country
-from ..tables.product_scans_by_country import create_scan
-from ..test_helper import mock_cursor, patch_context_manager
-from . import query
+from query.tables.product_scans_by_country import create_scan
+from query.test_helper import mock_cursor, patch_context_manager
 
 TEST_YEAR = 1900
 

--- a/query/services/scan.py
+++ b/query/services/scan.py
@@ -1,17 +1,16 @@
 """Routines that operate on product scan data. Scans are currently just loaded in a batch from logs
 but will hopefully be loaded from events in the future"""
 
-from query.tables.product_scans import insert_product_scans
-
-from ..database import get_transaction
-from ..models.scan import ProductScans
-from ..tables.loaded_tag import append_loaded_tags
-from ..tables.product import PRODUCT_SCANS_TAG, fixup_product_scans, normalize_code
-from ..tables.product_country import (
+from query.database import get_transaction
+from query.models.scan import ProductScans
+from query.tables.loaded_tag import append_loaded_tags
+from query.tables.product import PRODUCT_SCANS_TAG, fixup_product_scans, normalize_code
+from query.tables.product_country import (
     PRODUCT_COUNTRY_TAG,
     fixup_product_country_scans,
 )
-from ..tables.product_scans_by_country import insert_product_scans_by_country
+from query.tables.product_scans import insert_product_scans
+from query.tables.product_scans_by_country import insert_product_scans_by_country
 
 
 async def import_scans(scans: ProductScans, fully_loaded=False):

--- a/query/services/scan_test.py
+++ b/query/services/scan_test.py
@@ -1,16 +1,15 @@
 from unittest.mock import ANY, Mock, patch
 
+from query.database import get_transaction
+from query.models.scan import ProductScans
+from query.services import scan
 from query.services.query_find_test import TEST_YEAR
+from query.services.scan import import_scans
 from query.tables.collection_type import FOOD
-
-from ..database import get_transaction
-from ..models.scan import ProductScans
-from ..services.scan import import_scans
-from ..tables.country import add_all_countries
-from ..tables.product import PRODUCT_SCANS_TAG, normalize_code
-from ..tables.product_country import PRODUCT_COUNTRY_TAG
-from ..test_helper import random_code
-from . import scan
+from query.tables.country import add_all_countries
+from query.tables.product import PRODUCT_SCANS_TAG, normalize_code
+from query.tables.product_country import PRODUCT_COUNTRY_TAG
+from query.test_helper import random_code
 
 OLDEST_YEAR = TEST_YEAR - 5
 

--- a/query/tables/country.py
+++ b/query/tables/country.py
@@ -5,7 +5,7 @@ import os
 
 from asyncpg import Connection
 
-from ..database import create_record
+from query.database import create_record
 
 
 async def create_table(transaction):

--- a/query/tables/country_test.py
+++ b/query/tables/country_test.py
@@ -1,5 +1,5 @@
-from ..database import get_transaction
-from ..tables.country import add_all_countries
+from query.database import get_transaction
+from query.tables.country import add_all_countries
 
 
 async def test_add_all_countries():

--- a/query/tables/nutrient.py
+++ b/query/tables/nutrient.py
@@ -1,6 +1,6 @@
 """Full list of nutrient tags that appear on actual products"""
 
-from ..database import create_record, get_rows_affected
+from query.database import create_record, get_rows_affected
 
 
 async def create_table(transaction):

--- a/query/tables/product.py
+++ b/query/tables/product.py
@@ -6,14 +6,13 @@ from typing import List
 
 from asyncpg import Connection
 
+from query.database import create_record, get_rows_affected
+from query.models.product import Source
 from query.tables.collection_type import DELETED, FOOD, FOOD_OBSOLETE
 from query.tables.loaded_tag import PARTIAL_TAGS, check_tag_is_loaded
 from query.tables.product_country import delete_product_countries
-
-from ..database import create_record, get_rows_affected
-from ..models.product import Source
-from ..tables.product_ingredient import delete_ingredients
-from ..tables.product_tags import TAG_TABLES, delete_tags
+from query.tables.product_ingredient import delete_ingredients
+from query.tables.product_tags import TAG_TABLES, delete_tags
 
 PRODUCT_FIELD_BASE_COLUMNS = {
     "code": "code",

--- a/query/tables/product_country.py
+++ b/query/tables/product_country.py
@@ -2,10 +2,9 @@
 The recent and total scans columns are used for popularity sorting and need to be refreshed each year
 from the product_scans_by_country"""
 
+from query.database import create_record
 from query.tables.collection_type import DELETED, FOOD, FOOD_OBSOLETE
 from query.tables.loaded_tag import PARTIAL_TAGS
-
-from ..database import create_record
 
 PRODUCT_COUNTRY_TAG = "product_country"
 PARTIAL_TAGS.append(PRODUCT_COUNTRY_TAG)

--- a/query/tables/product_ingredient.py
+++ b/query/tables/product_ingredient.py
@@ -4,9 +4,8 @@ There is currently no API to query this data, it is just being used internally t
 
 from asyncpg import Connection
 
+from query.database import get_rows_affected
 from query.tables.collection_type import DELETED, FOOD, FOOD_OBSOLETE
-
-from ..database import get_rows_affected
 
 # Note we can't list explicit fields here because of the potentially unlimited nesting of sub-ingredients
 INGREDIENTS_TAG = "ingredients"

--- a/query/tables/product_nutrient.py
+++ b/query/tables/product_nutrient.py
@@ -2,9 +2,8 @@
 
 from asyncpg import Connection
 
+from query.database import create_record, get_rows_affected
 from query.tables.nutrient import create_nutrients_from_staging
-
-from ..database import create_record, get_rows_affected
 
 NUTRIENT_TAG = "nutriments"
 NUTRITION_TAG = "nutrition.aggregated_set.nutrients"

--- a/query/tables/product_scans.py
+++ b/query/tables/product_scans.py
@@ -1,8 +1,7 @@
 """The Number of scans for each product by year"""
 
 from query.database import create_record
-
-from ..models.scan import ProductScans
+from query.models.scan import ProductScans
 
 
 async def create_product_scans_table(transaction):

--- a/query/tables/product_scans_by_country.py
+++ b/query/tables/product_scans_by_country.py
@@ -1,7 +1,7 @@
 """The Number of scans for each product by country and year"""
 
-from ..database import create_record
-from ..models.scan import ProductScans
+from query.database import create_record
+from query.models.scan import ProductScans
 
 
 async def create_table(transaction):

--- a/query/tables/product_tags.py
+++ b/query/tables/product_tags.py
@@ -1,9 +1,8 @@
 """The set of tables that store product tags. Each tag is simply an array of values on the product.
 The order of tags is not preserved"""
 
+from query.database import create_record, get_rows_affected
 from query.tables.collection_type import DELETED, FOOD, FOOD_OBSOLETE
-
-from ..database import create_record, get_rows_affected
 
 COUNTRIES_TAG = "countries_tags"
 tag_tables_v1 = {

--- a/query/tables/product_test.py
+++ b/query/tables/product_test.py
@@ -1,6 +1,6 @@
-from ..database import get_transaction
-from ..tables.product import create_product, normalize_code
-from ..test_helper import random_code
+from query.database import get_transaction
+from query.tables.product import create_product, normalize_code
+from query.test_helper import random_code
 
 
 async def test_create_product():

--- a/query/tables/product_update.py
+++ b/query/tables/product_update.py
@@ -4,9 +4,9 @@ from typing import List
 
 from asyncpg import Connection
 
-from ..tables.contributor import create_contributors_from_events
-from ..tables.product import create_minimal_product_from_events
-from ..tables.update_type import create_update_types_from_events
+from query.tables.contributor import create_contributors_from_events
+from query.tables.product import create_minimal_product_from_events
+from query.tables.update_type import create_update_types_from_events
 
 
 async def create_table(transaction: Connection):

--- a/query/tables/product_update_event.py
+++ b/query/tables/product_update_event.py
@@ -5,8 +5,8 @@ from typing import List
 
 from asyncpg import Connection
 
-from ..models.domain_event import DomainEvent
-from ..tables.product_update import create_updates_from_events
+from query.models.domain_event import DomainEvent
+from query.tables.product_update import create_updates_from_events
 
 
 async def create_table(transaction):

--- a/query/tables/product_update_event_test.py
+++ b/query/tables/product_update_event_test.py
@@ -1,7 +1,7 @@
-from ..database import get_transaction
-from ..services.event_test import sample_event
-from ..tables.product_update_event import create_events
-from ..test_helper import random_code
+from query.database import get_transaction
+from query.services.event_test import sample_event
+from query.tables.product_update_event import create_events
+from query.test_helper import random_code
 
 
 async def test_create_events_should_ignore_duplicates():

--- a/query/views/product_updates_by_owner.py
+++ b/query/views/product_updates_by_owner.py
@@ -1,6 +1,6 @@
 """A view to return aggregated product update information"""
 
-from ..database import config_settings
+from query.database import config_settings
 
 
 async def create_view(transaction):

--- a/query/views/product_updates_by_owner_test.py
+++ b/query/views/product_updates_by_owner_test.py
@@ -3,11 +3,11 @@ from typing import Any, AsyncGenerator
 
 import asyncpg
 
-from ..config import config_settings
-from ..database import get_transaction
-from ..services.event_test import sample_event
-from ..tables.product_update_event import create_events
-from ..test_helper import random_code
+from query.config import config_settings
+from query.database import get_transaction
+from query.services.event_test import sample_event
+from query.tables.product_update_event import create_events
+from query.test_helper import random_code
 
 
 @asynccontextmanager

--- a/query/views/views.py
+++ b/query/views/views.py
@@ -1,6 +1,6 @@
 """Creates a view only user to support direct database queries for dashboards, etc."""
 
-from ..config import config_settings
+from query.config import config_settings
 
 
 async def create_schema(transaction):


### PR DESCRIPTION
### What
Had previously adopted a convention of using relative imports for local module imports and absolute for libraries, but not able to enforce this with linting and tools like VSCode use absolte imports by default when making suggestions.
