### PR TITLE
fix: Correction to docker compose file separator

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -164,7 +164,7 @@ jobs:
             echo "COMPOSE_PROFILES=${{ env.COMPOSE_PROFILES }}" >> .env
             echo "COMPOSE_PATH_SEPARATOR=," >> .env
             echo "RESTART_POLICY=always" >> .env
-            echo "COMPOSE_FILE=docker-compose.yml;docker/monitor.yml" >> .env
+            echo "COMPOSE_FILE=docker-compose.yml,docker/monitor.yml" >> .env
             echo "TAG=sha-${{ github.sha }}" >> .env
 
             # App environment variables


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
- Was using a semicolon instead of a comma