### PR TITLE
fix: Prevent concurrent imports and stop importing during migrations

### DIFF
--- a/docs/decisions/update-concurrency.md
+++ b/docs/decisions/update-concurrency.md
@@ -1,0 +1,22 @@
+# Dealing with concurrency during updates and migrations
+
+## Context and Problem Statement
+
+We don't want Redis updates to run at the same time as incremental sync as this could try to update the same product twice.
+
+In addition, if we are running migrations we don't want updates to run as these can lock the tables we are migrating or be blocked if the migration is already running. This can cause excessive client generation and messages like "sorry, too many clients already".
+
+This document describes the strategy for managing concurrency.
+
+## Decision Drivers
+
+* Updates can be paused during migrations as long as queries still work
+* Redis updates should be quick whereas incremental or full sync will take longer
+
+## Decision Outcome
+
+Migrations should wait for all current updates to finish and then block further updates by locking the settings table and setting the pre_migration_message_id.
+
+All other updates should also try to lock the settings table before proceeding. Once they get the lock then they should test to see if the pre_migration_message_id column is set and if it is they should abort the operation as this means a migration is running and the service is due to be re-started.
+
+Incremental and full imports should block for the entire import, even if the batch is split into multiple transactions.

--- a/query/conftest.py
+++ b/query/conftest.py
@@ -6,8 +6,9 @@ from testcontainers.postgres import PostgresContainer
 from testcontainers.redis import RedisContainer
 
 from query.config import config_settings
-from query.database import create_connection_pool, get_transaction
+from query.database import create_connection_pool
 from query.migrator import migrate_database
+from query.tables.settings import apply_pre_migration_message_id
 
 
 # Don't prefix with "Test" as otherwise pytest thinks this is a test class
@@ -50,8 +51,7 @@ async def setup(request):
     await migrate_database(True)
     
     # Clear the pre-migration message id so that tests don't think a migration has just finished
-    async with get_transaction() as transaction:
-        await transaction.execute("UPDATE settings SET pre_migration_message_id = NULL")
+    await apply_pre_migration_message_id()
 
     # Create connection pool. Note only do this after migrations as the pool might contain connections that don't have the search_path set up, etc.
     pool = await create_connection_pool()

--- a/query/conftest.py
+++ b/query/conftest.py
@@ -49,7 +49,7 @@ async def setup(request):
 
     # Always run migrations, even if not using testcontainers
     await migrate_database(True)
-    
+
     # Clear the pre-migration message id so that tests don't think a migration has just finished
     await apply_pre_migration_message_id()
 

--- a/query/conftest.py
+++ b/query/conftest.py
@@ -6,7 +6,7 @@ from testcontainers.postgres import PostgresContainer
 from testcontainers.redis import RedisContainer
 
 from query.config import config_settings
-from query.database import create_connection_pool
+from query.database import create_connection_pool, get_transaction
 from query.migrator import migrate_database
 
 
@@ -48,6 +48,10 @@ async def setup(request):
 
     # Always run migrations, even if not using testcontainers
     await migrate_database(True)
+    
+    # Clear the pre-migration message id so that tests don't think a migration has just finished
+    async with get_transaction() as transaction:
+        await transaction.execute("UPDATE settings SET pre_migration_message_id = NULL")
 
     # Create connection pool. Note only do this after migrations as the pool might contain connections that don't have the search_path set up, etc.
     pool = await create_connection_pool()

--- a/query/events.py
+++ b/query/events.py
@@ -15,6 +15,7 @@ from query.models.domain_event import DomainEvent
 from query.services.event import STREAM_NAME, process_events
 from query.tables.settings import (
     apply_pre_migration_message_id,
+    can_import,
     get_last_message_id,
     set_last_message_id,
 )
@@ -57,9 +58,10 @@ async def redis_listener():
                 if response:
                     async with get_transaction() as transaction:
                         # Lock the settings table so that we don't overlap with imports
-                        pre_migration_message_id = await transaction.fetchval("SELECT pre_migration_message_id FROM settings FOR UPDATE")
-                        # Quite the listener if a migration has just finished
-                        if pre_migration_message_id:
+                        if not await can_import(transaction):
+                            logger.warning(
+                                "Quitting Redis listener as a migration is running"
+                            )
                             return
 
                         await messages_received(transaction, response)

--- a/query/events.py
+++ b/query/events.py
@@ -56,6 +56,12 @@ async def redis_listener():
                 # response is an array of tuples of stream name and array of messages
                 if response:
                     async with get_transaction() as transaction:
+                        # Lock the settings table so that we don't overlap with imports
+                        pre_migration_message_id = await transaction.fetchval("SELECT pre_migration_message_id FROM settings FOR UPDATE")
+                        # Quite the listener if a migration has just finished
+                        if pre_migration_message_id:
+                            return
+
                         await messages_received(transaction, response)
                         # Each message is a tuple of the message id followed by a dict that is the payload
                         last_message_id = response[0][1][-1][0]

--- a/query/events.py
+++ b/query/events.py
@@ -14,8 +14,8 @@ from query.database import get_transaction, strip_nuls
 from query.models.domain_event import DomainEvent
 from query.services.event import STREAM_NAME, process_events
 from query.tables.settings import (
+    acquire_import_lock,
     apply_pre_migration_message_id,
-    can_import,
     get_last_message_id,
     set_last_message_id,
 )
@@ -58,7 +58,8 @@ async def redis_listener():
                 if response:
                     async with get_transaction() as transaction:
                         # Lock the settings table so that we don't overlap with imports
-                        if not await can_import(transaction):
+                        if not await acquire_import_lock(transaction):
+                            # Migration has started. Stop the listener as a new instance of the service will be started after the migration
                             logger.warning(
                                 "Quitting Redis listener as a migration is running"
                             )

--- a/query/events_test.py
+++ b/query/events_test.py
@@ -247,6 +247,73 @@ async def test_listener_retrys_on_error(
         redis_container.stop()
 
 
+@patch.object(events, "get_last_message_id")
+@patch.object(events, "set_last_message_id")
+@patch.object(events, "messages_received")
+async def test_listener_waits_for_lock_on_settings_before_proceeding(
+    messages_received: Mock, set_id: Mock, get_id: Mock
+):
+    async with redis_client() as redis:
+        # Get the most recent message id so we don't pick up old messages
+        get_id.return_value = await get_last_message_id(redis, STREAM_NAME)
+
+        # Add a message
+        product_code = random_code()
+        message_id1 = await add_test_message(redis, product_code)
+
+        async with get_transaction() as lock_transaction:
+            # Lock the settings table as if we were doing an import
+            await lock_transaction.fetchval("SELECT pre_migration_message_id FROM settings FOR UPDATE")
+
+            # Start the redis listener
+            redis_listener_task = asyncio.create_task(redis_listener())
+            message_processed_task = asyncio.create_task(messages_processed(messages_received))
+            await asyncio.sleep(0.3) # Sleep needs to allow messages_processed to run at least once
+            assert not message_processed_task.done()
+
+        await message_processed_task
+
+        # Settings should be updated with the last message id
+        assert set_id.call_args[0][1] == message_id1
+
+        await cancel_task(redis_listener_task)
+
+
+@patch.object(events, "get_last_message_id")
+@patch.object(events, "set_last_message_id")
+@patch.object(events, "messages_received")
+async def test_listener_quits_if_migration_has_just_heppened(
+    messages_received: Mock, set_id: Mock, get_id: Mock
+):
+    async with redis_client() as redis:
+        # Get the most recent message id so we don't pick up old messages
+        get_id.return_value = await get_last_message_id(redis, STREAM_NAME)
+
+        # Add a message
+        await add_test_message(redis, random_code())
+
+        try:
+            async with get_transaction() as migration_transaction:
+                # Lock the settings table as if we were doing a migration
+                await migration_transaction.execute("UPDATE settings SET pre_migration_message_id = 1")
+
+                # Start the redis listener
+                redis_listener_task = asyncio.create_task(redis_listener())
+                await asyncio.sleep(0.2)
+                # Should wait for the lock to finish
+                assert not messages_received.called
+                assert not redis_listener_task.done()
+
+            # Transaction completes, redis listener should finish
+            await asyncio.sleep(0.1)
+            assert redis_listener_task.done()
+            assert not messages_received.called
+            assert not set_id.called
+        finally:
+            async with get_transaction() as migration_transaction:
+                await migration_transaction.execute("UPDATE settings SET pre_migration_message_id = NULL")
+
+
 @patch.object(event, "import_with_filter")
 async def test_messages_received_strips_nulls(import_with_filter: Mock):
     async with get_transaction() as transaction:

--- a/query/events_test.py
+++ b/query/events_test.py
@@ -263,12 +263,18 @@ async def test_listener_waits_for_lock_on_settings_before_proceeding(
 
         async with get_transaction() as lock_transaction:
             # Lock the settings table as if we were doing an import
-            await lock_transaction.fetchval("SELECT pre_migration_message_id FROM settings FOR UPDATE")
+            await lock_transaction.fetchval(
+                "SELECT pre_migration_message_id FROM settings FOR UPDATE"
+            )
 
             # Start the redis listener
             redis_listener_task = asyncio.create_task(redis_listener())
-            message_processed_task = asyncio.create_task(messages_processed(messages_received))
-            await asyncio.sleep(0.3) # Sleep needs to allow messages_processed to run at least once
+            message_processed_task = asyncio.create_task(
+                messages_processed(messages_received)
+            )
+            await asyncio.sleep(
+                0.3
+            )  # Sleep needs to allow messages_processed to run at least once
             assert not message_processed_task.done()
 
         await message_processed_task
@@ -282,8 +288,9 @@ async def test_listener_waits_for_lock_on_settings_before_proceeding(
 @patch.object(events, "get_last_message_id")
 @patch.object(events, "set_last_message_id")
 @patch.object(events, "messages_received")
+@patch.object(events, "logger")
 async def test_listener_quits_if_migration_has_just_heppened(
-    messages_received: Mock, set_id: Mock, get_id: Mock
+    logger_mock: Mock, messages_received: Mock, set_id: Mock, get_id: Mock
 ):
     async with redis_client() as redis:
         # Get the most recent message id so we don't pick up old messages
@@ -295,7 +302,9 @@ async def test_listener_quits_if_migration_has_just_heppened(
         try:
             async with get_transaction() as migration_transaction:
                 # Lock the settings table as if we were doing a migration
-                await migration_transaction.execute("UPDATE settings SET pre_migration_message_id = 1")
+                await migration_transaction.execute(
+                    "UPDATE settings SET pre_migration_message_id = 1"
+                )
 
                 # Start the redis listener
                 redis_listener_task = asyncio.create_task(redis_listener())
@@ -304,14 +313,17 @@ async def test_listener_quits_if_migration_has_just_heppened(
                 assert not messages_received.called
                 assert not redis_listener_task.done()
 
-            # Transaction completes, redis listener should finish
+            # Transaction completes, redis listener should finish and log a warning
             await asyncio.sleep(0.1)
             assert redis_listener_task.done()
             assert not messages_received.called
             assert not set_id.called
+            assert logger_mock.warning.called
         finally:
             async with get_transaction() as migration_transaction:
-                await migration_transaction.execute("UPDATE settings SET pre_migration_message_id = NULL")
+                await migration_transaction.execute(
+                    "UPDATE settings SET pre_migration_message_id = NULL"
+                )
 
 
 @patch.object(event, "import_with_filter")

--- a/query/events_test.py
+++ b/query/events_test.py
@@ -277,7 +277,7 @@ async def test_listener_waits_for_lock_on_settings_before_proceeding(
             )  # Sleep needs to allow messages_processed to run at least once
             assert not message_processed_task.done()
 
-        await message_processed_task
+        assert (await message_processed_task) is None
 
         # Settings should be updated with the last message id
         assert set_id.call_args[0][1] == message_id1

--- a/query/services/ingestion.py
+++ b/query/services/ingestion.py
@@ -389,7 +389,10 @@ async def import_from_mongo(from_date: str = None, product_type=ProductType.food
     
     # Lock the settings table while we are doing the update to prevent multiple concurrent imports.
     async with get_transaction() as lock_transaction:
-        await lock_transaction.fetchval("SELECT pre_migration_message_id FROM settings FOR UPDATE");
+        pre_migration_message_id = await lock_transaction.fetchval("SELECT pre_migration_message_id FROM settings FOR UPDATE");
+        if pre_migration_message_id:
+            logger.warning("Skipping as a migration has just finished")
+            return
 
         # If from_date is supplied or empty (as opposed to not supplied) then do an incremental import
         source = Source.full_load if from_date == None else Source.incremental_load

--- a/query/services/ingestion.py
+++ b/query/services/ingestion.py
@@ -44,6 +44,7 @@ from query.tables.product_tags import (
     TAG_TABLES,
     create_tags_from_staging,
 )
+from query.tables.settings import can_import
 
 logger = logging.getLogger(__name__)
 
@@ -386,12 +387,11 @@ async def import_from_mongo(from_date: str = None, product_type=ProductType.food
     If the date specified is None then full import is performed.
     If the date is empty then products updated since the last incremental import will be loaded
     """
-    
+
     # Lock the settings table while we are doing the update to prevent multiple concurrent imports.
     async with get_transaction() as lock_transaction:
-        pre_migration_message_id = await lock_transaction.fetchval("SELECT pre_migration_message_id FROM settings FOR UPDATE");
-        if pre_migration_message_id:
-            logger.warning("Skipping as a migration has just finished")
+        if not await can_import(lock_transaction):
+            logger.warning("Skipping as a migration is running")
             return
 
         # If from_date is supplied or empty (as opposed to not supplied) then do an incremental import

--- a/query/services/ingestion.py
+++ b/query/services/ingestion.py
@@ -381,21 +381,16 @@ async def apply_product_updates(
             retrying = True
 
 
-import_running = {}
-
-
 async def import_from_mongo(from_date: str = None, product_type=ProductType.food):
     """Imports data from MongoDB that has been updated since the date specified.
     If the date specified is None then full import is performed.
     If the date is empty then products updated since the last incremental import will be loaded
     """
-    global import_running
-    if import_running.get(product_type):
-        logger.warning("Skipping as import already running")
-        return
+    
+    # Lock the settings table while we are doing the update to prevent multiple concurrent imports.
+    async with get_transaction() as lock_transaction:
+        await lock_transaction.fetchval("SELECT pre_migration_message_id FROM settings FOR UPDATE");
 
-    import_running[product_type] = True
-    try:
         # If from_date is supplied or empty (as opposed to not supplied) then do an incremental import
         source = Source.full_load if from_date == None else Source.incremental_load
         async with get_transaction() as transaction:
@@ -407,5 +402,3 @@ async def import_from_mongo(from_date: str = None, product_type=ProductType.food
                 from_datetime=from_datetime,
                 product_type=product_type,
             )
-    finally:
-        import_running[product_type] = False

--- a/query/services/ingestion.py
+++ b/query/services/ingestion.py
@@ -44,7 +44,7 @@ from query.tables.product_tags import (
     TAG_TABLES,
     create_tags_from_staging,
 )
-from query.tables.settings import can_import
+from query.tables.settings import acquire_import_lock
 
 logger = logging.getLogger(__name__)
 
@@ -390,7 +390,7 @@ async def import_from_mongo(from_date: str = None, product_type=ProductType.food
 
     # Lock the settings table while we are doing the update to prevent multiple concurrent imports.
     async with get_transaction() as lock_transaction:
-        if not await can_import(lock_transaction):
+        if not await acquire_import_lock(lock_transaction):
             logger.warning("Skipping as a migration is running")
             return
 

--- a/query/services/ingestion_test.py
+++ b/query/services/ingestion_test.py
@@ -412,7 +412,7 @@ async def test_set_last_updated_correctly_if_one_product_has_an_invalid_date(
 
 
 @patch.object(ingestion, "import_with_filter")
-async def test_skip_if_already_importing(
+async def test_wait_if_already_importing(
     import_with_filter: Mock,
 ):
     import_running = False
@@ -440,6 +440,27 @@ async def test_skip_if_already_importing(
     
     # But import_with_filter was called twice
     assert import_with_filter.call_count == 2
+
+
+@patch.object(ingestion, "import_with_filter")
+async def test_skip_if_migrating(
+    import_with_filter: Mock,
+):
+    try:
+        # given: migration is running
+        async with get_transaction() as migration_transaction:
+            await migration_transaction.execute("UPDATE settings SET pre_migration_message_id = 1")
+
+            # When doing an import. Don't await here as should be blocked by above lock
+            import_task = asyncio.create_task(ingestion.import_from_mongo("2000-01-01"))
+
+        await import_task
+
+        # then: import should be skipped
+        assert import_with_filter.call_count == 0
+    finally:
+        async with get_transaction() as migration_transaction:
+            await migration_transaction.execute("UPDATE settings SET pre_migration_message_id = NULL")
 
 
 @patch.object(ingestion, "find_products")

--- a/query/services/ingestion_test.py
+++ b/query/services/ingestion_test.py
@@ -417,6 +417,7 @@ async def test_wait_if_already_importing(
 ):
     import_running = False
     concurrent_call = False
+
     async def alert_concurrent_import(*args, **kwargs):
         nonlocal import_running, concurrent_call
         if import_running:
@@ -426,7 +427,7 @@ async def test_wait_if_already_importing(
         import_running = False
 
     import_with_filter.side_effect = alert_concurrent_import
-    
+
     # given: import already running
     # Note, don't await. In python need to use create_task to ensure the routine actually starts
     first_import = asyncio.create_task(ingestion.import_from_mongo("2000-01-01"))
@@ -437,19 +438,23 @@ async def test_wait_if_already_importing(
 
     # then: no concurrent imports should happen
     assert concurrent_call == False
-    
+
     # But import_with_filter was called twice
     assert import_with_filter.call_count == 2
 
 
 @patch.object(ingestion, "import_with_filter")
+@patch.object(ingestion, "logger")
 async def test_skip_if_migrating(
+    logger: Mock,
     import_with_filter: Mock,
 ):
     try:
         # given: migration is running
         async with get_transaction() as migration_transaction:
-            await migration_transaction.execute("UPDATE settings SET pre_migration_message_id = 1")
+            await migration_transaction.execute(
+                "UPDATE settings SET pre_migration_message_id = 1"
+            )
 
             # When doing an import. Don't await here as should be blocked by above lock
             import_task = asyncio.create_task(ingestion.import_from_mongo("2000-01-01"))
@@ -458,9 +463,13 @@ async def test_skip_if_migrating(
 
         # then: import should be skipped
         assert import_with_filter.call_count == 0
+        # And a warning should be logged
+        assert logger.warning.called
     finally:
         async with get_transaction() as migration_transaction:
-            await migration_transaction.execute("UPDATE settings SET pre_migration_message_id = NULL")
+            await migration_transaction.execute(
+                "UPDATE settings SET pre_migration_message_id = NULL"
+            )
 
 
 @patch.object(ingestion, "find_products")
@@ -514,32 +523,6 @@ async def test_import_from_event_source_should_always_update_product(
         assert product_existing["source"] == Source.event
         assert product_existing["process_id"] != 10
         assert product_existing["last_processed"] > last_processed
-
-
-# The following doesn't work because patching is not thread-safe. See https://gist.github.com/styoe/38d5445cfa482024af533a4079b703c1
-# async def test_not_get_an_error_with_concurrent_imports():
-#     products = get_test_products()
-
-#     async def one_import():
-#         with patch.object(ingestion, "find_products") as find_products_mock:
-#             patch_context_manager(find_products_mock, mock_cursor(products))
-#             async with get_transaction() as transaction:
-#                 await ingestion.import_with_filter(
-#                     transaction,
-#                     {"code": {"$in": [products[0]["code"], products[1]["code"]]}},
-#                     Source.event,
-#                 )
-
-#     running_imports = []
-#     for i in range(11):
-#         running_imports.append(one_import())
-
-#     await asyncio.gather(*running_imports)
-#     async with get_transaction() as transaction:
-#         found_product = await transaction.fetch(
-#             "SELECT * FROM product WHERE code = $1", products[0]["code"]
-#         )
-#         assert len(found_product) == 1
 
 
 @patch.object(ingestion, "find_products")

--- a/query/services/ingestion_test.py
+++ b/query/services/ingestion_test.py
@@ -459,7 +459,7 @@ async def test_skip_if_migrating(
             # When doing an import. Don't await here as should be blocked by above lock
             import_task = asyncio.create_task(ingestion.import_from_mongo("2000-01-01"))
 
-        await import_task
+        assert (await import_task) is None
 
         # then: import should be skipped
         assert import_with_filter.call_count == 0

--- a/query/services/ingestion_test.py
+++ b/query/services/ingestion_test.py
@@ -411,15 +411,23 @@ async def test_set_last_updated_correctly_if_one_product_has_an_invalid_date(
         )
 
 
-@patch.object(ingestion, "logger")
-@patch.object(ingestion, "find_products")
+@patch.object(ingestion, "import_with_filter")
 async def test_skip_if_already_importing(
-    find_products_mock: Mock,
-    logger_mock: Mock,
+    import_with_filter: Mock,
 ):
+    import_running = False
+    concurrent_call = False
+    async def alert_concurrent_import(*args, **kwargs):
+        nonlocal import_running, concurrent_call
+        if import_running:
+            concurrent_call = True
+        import_running = True
+        await asyncio.sleep(0.2)
+        import_running = False
+
+    import_with_filter.side_effect = alert_concurrent_import
+    
     # given: import already running
-    products = get_test_products()
-    patch_context_manager(find_products_mock, mock_cursor(products))
     # Note, don't await. In python need to use create_task to ensure the routine actually starts
     first_import = asyncio.create_task(ingestion.import_from_mongo("2000-01-01"))
 
@@ -427,8 +435,11 @@ async def test_skip_if_already_importing(
     await ingestion.import_from_mongo("2001-01-01")
     await first_import
 
-    # then: second import just logs a warning
-    assert logger_mock.warning.called
+    # then: no concurrent imports should happen
+    assert concurrent_call == False
+    
+    # But import_with_filter was called twice
+    assert import_with_filter.call_count == 2
 
 
 @patch.object(ingestion, "find_products")

--- a/query/services/ingestion_test.py
+++ b/query/services/ingestion_test.py
@@ -118,7 +118,9 @@ async def test_import_from_mongo_should_import_a_new_product_update_existing_pro
 
         # Fixing #257: Create an existing product_country for a countries_tag not included in the import that has no code
         no_code_country = await create_country(transaction, tag=random_code())
-        await create_product_country(transaction, product_existing, no_code_country, 0, 0)
+        await create_product_country(
+            transaction, product_existing, no_code_country, 0, 0
+        )
 
         product_unchanged = await create_product(
             transaction, code=random_code(), process_id=0

--- a/query/tables/settings.py
+++ b/query/tables/settings.py
@@ -37,6 +37,8 @@ async def set_pre_migration_message_id():
     """Makes a note of the last Redis message_id before a data migration starts.
     Messages after this will be replayed on the new version once the upgrade finishes
     """
+    logger.info("Waiting for imports to finish before starting migrations")
+
     # Use a separate transaction so that this doesn't block the current instance from updating last_message_id
     async with get_transaction() as transaction:
         try:

--- a/query/tables/settings.py
+++ b/query/tables/settings.py
@@ -65,8 +65,9 @@ async def apply_pre_migration_message_id():
             logger.info(f"Resuming messages from id: {setting[0]['last_message_id']}")
 
 
-async def can_import(transaction) -> bool:
-    """Check if we can start an import or if a migration has just finished"""
+async def acquire_import_lock(transaction) -> bool:
+    """Check if we can start an import or if a migration has just finished. Locks the settings table
+    if successful to prevent other imports and migrations from running concurrently"""
     pre_migration_message_id = await transaction.fetchval(
         "SELECT pre_migration_message_id FROM settings FOR UPDATE"
     )

--- a/query/tables/settings.py
+++ b/query/tables/settings.py
@@ -61,3 +61,11 @@ async def apply_pre_migration_message_id():
         )
         if len(setting) == 1:
             logger.info(f"Resuming messages from id: {setting[0]['last_message_id']}")
+
+
+async def can_import(transaction) -> bool:
+    """Check if we can start an import or if a migration has just finished"""
+    pre_migration_message_id = await transaction.fetchval(
+        "SELECT pre_migration_message_id FROM settings FOR UPDATE"
+    )
+    return not pre_migration_message_id

--- a/query/tables/settings_test.py
+++ b/query/tables/settings_test.py
@@ -1,0 +1,17 @@
+import asyncio
+
+from query.database import get_transaction
+from query.tables.settings import set_pre_migration_message_id
+
+
+async def test_migration_doesnt_start_until_imports_are_finished():
+    """Test that if an import is running then a migration doesn't start until it finishes"""
+    async with get_transaction() as transaction:
+        # Lock the settings table as if we were doing an import
+        await transaction.fetchval("SELECT pre_migration_message_id FROM settings FOR UPDATE")
+        task = asyncio.create_task(set_pre_migration_message_id())
+        await asyncio.sleep(0.1)
+        
+        assert not task.done()
+    await task
+    assert task.done()

--- a/query/tables/settings_test.py
+++ b/query/tables/settings_test.py
@@ -15,5 +15,5 @@ async def test_migration_doesnt_start_until_imports_are_finished():
         await asyncio.sleep(0.1)
 
         assert not task.done()
-    await task
+    assert (await task) is None
     assert task.done()

--- a/query/tables/settings_test.py
+++ b/query/tables/settings_test.py
@@ -8,10 +8,12 @@ async def test_migration_doesnt_start_until_imports_are_finished():
     """Test that if an import is running then a migration doesn't start until it finishes"""
     async with get_transaction() as transaction:
         # Lock the settings table as if we were doing an import
-        await transaction.fetchval("SELECT pre_migration_message_id FROM settings FOR UPDATE")
+        await transaction.fetchval(
+            "SELECT pre_migration_message_id FROM settings FOR UPDATE"
+        )
         task = asyncio.create_task(set_pre_migration_message_id())
         await asyncio.sleep(0.1)
-        
+
         assert not task.done()
     await task
     assert task.done()


### PR DESCRIPTION
### What
During large migrations imports can become blocked because they are trying to update a table that is being migrated. This can use up connections which can then block queries.

This PR abandons all imports while migrations are running. Event imports will resume at the last message id that was processed prior to the migration starting.