### PR TITLE
fix: Import was not cleaning up product_country records that linked to a country with no code

### DIFF
--- a/query/services/ingestion_test.py
+++ b/query/services/ingestion_test.py
@@ -18,7 +18,7 @@ from query.tables.collection_type import (
     get_last_updated,
     set_last_updated,
 )
-from query.tables.country import add_all_countries, get_country
+from query.tables.country import add_all_countries, create_country, get_country
 from query.tables.nutrient import get_nutrient
 from query.tables.product import create_product, get_product, get_product_by_id
 from query.tables.product_country import create_product_country, get_product_countries
@@ -116,6 +116,10 @@ async def test_import_from_mongo_should_import_a_new_product_update_existing_pro
         uk = await get_country(transaction, "en:united-kingdom")
         await create_product_country(transaction, product_existing, uk, 2, 10)
 
+        # Fixing #257: Create an existing product_country for a countries_tag not included in the import that has no code
+        no_code_country = await create_country(transaction, tag=random_code())
+        await create_product_country(transaction, product_existing, no_code_country, 0, 0)
+
         product_unchanged = await create_product(
             transaction, code=random_code(), process_id=0
         )
@@ -162,7 +166,7 @@ async def test_import_from_mongo_should_import_a_new_product_update_existing_pro
         assert any(i for i in ingredients_existing if i["value"] == "old_ingredient")
         assert any(i for i in ingredients_existing if i["value"] == "new_ingredient")
 
-        # should create an entry for each country plus world but not UK
+        # should create an entry for each country plus world but not UK or the random country with no code
         countries_existing = await get_product_countries(transaction, product_existing)
         assert len(countries_existing) == 3
         existing_world = next(

--- a/query/tables/product_country.py
+++ b/query/tables/product_country.py
@@ -95,7 +95,7 @@ async def fixup_product_countries(transaction, collection_id):
                 country c
             WHERE pc.product_id = pt.id
             AND c.id = pc.country_id
-            AND c.code <> 'world'
+            AND c.tag <> 'en:world'
             AND NOT EXISTS (SELECT * FROM product_countries_tag pct WHERE pct.product_id = pc.product_id AND pct.value = c.tag)
         """)
 
@@ -113,7 +113,7 @@ async def fixup_product_country_scans(transaction, current_year, oldest_year):
             from product_scans_by_country s
             join product p on p.id = s.product_id
             join country c on c.id = s.country_id
-            where (c.code = 'world' or
+            where (c.tag = 'en:world' or
                 exists (select * from product_countries_tag t where t.product_id = s.product_id and t.value = c.tag))
             group by product_id, p.collection_id, country_id
             on conflict (product_id, country_id)


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
The SQL that was removing product countries where no product countries tag was present was checking the code not being qual to 'world' but code is optional so this was failing to delete countries with a null code

### Fixes bug(s)
- #257
