### PR TITLE
fix: Replace obsolete with collection_id in product_country index

### DIFF
--- a/query/events.py
+++ b/query/events.py
@@ -25,7 +25,10 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def redis_client() -> AsyncGenerator[redis.Redis, Any]:
     """Creates a connection to Redis"""
-    client = redis.from_url(config_settings.REDIS_URL, decode_responses=True)
+    # Timeout increased to 10s to avoid periodic network:TimeoutError. May need to investigate further if this isn't enough
+    client = redis.from_url(
+        config_settings.REDIS_URL, decode_responses=True, socket_timeout=10.0
+    )
     try:
         yield client
     finally:
@@ -63,6 +66,8 @@ async def redis_listener():
 
                 # Reset error count on success
                 error_count = 0
+                # Add small delay to avaoid hammering Redis
+                await asyncio.sleep(0.1)
 
             except Exception as e:
                 retry_in = get_retry_interval()

--- a/query/migrations/Migration20260608194900.py
+++ b/query/migrations/Migration20260608194900.py
@@ -1,0 +1,5 @@
+from query.tables import product_country
+
+
+async def up(transaction):
+    await product_country.migration_fix_index(transaction)

--- a/query/tables/product_country.py
+++ b/query/tables/product_country.py
@@ -54,6 +54,15 @@ async def migration_add_collection(transaction):
     )
 
 
+async def migration_fix_index(transaction):
+    await transaction.execute(
+        "DROP INDEX IF EXISTS product_country_ix1;"
+    )
+    await transaction.execute(
+        "CREATE INDEX product_country_ix1 ON product_country (country_id, collection_id, recent_scans DESC, total_scans DESC, product_id);"
+    )
+
+
 async def create_product_country(
     transaction, product, country, recent_scans, total_scans
 ):


### PR DESCRIPTION
### What
Searches on product country now filter by the collection_id and not the obsolete flag so the index was not being used.

Also increases Redis timeout to try and reduce timeout errors seen in logs.

### Fixes bug(s)
- #331