### PR TITLE
fix: Search MongoDB by code, not _id. Also remove invalid product codes

### DIFF
--- a/query/migrations/Migration20260618142400.py
+++ b/query/migrations/Migration20260618142400.py
@@ -1,0 +1,7 @@
+from query.tables import product_update
+
+
+async def up(transaction):
+    # Delete products where the code doesn't match current conventions
+    await transaction.execute("DELETE FROM product WHERE length(code) > 13 and code LIKE '0%';")
+    await product_update.migration_add_product_foreign_key(transaction)

--- a/query/migrations/Migration20260618142400.py
+++ b/query/migrations/Migration20260618142400.py
@@ -3,5 +3,8 @@ from query.tables import product_update
 
 async def up(transaction):
     # Delete products where the code doesn't match current conventions
-    await transaction.execute("DELETE FROM product WHERE length(code) > 13 and code LIKE '0%';")
+    await transaction.execute(
+        """DELETE FROM product WHERE (length(code) > 13 and code LIKE '0%')
+                              OR (length(code) < 13 and length(code) <> 8);"""
+    )
     await product_update.migration_add_product_foreign_key(transaction)

--- a/query/services/query.py
+++ b/query/services/query.py
@@ -226,8 +226,14 @@ async def find(
                 mongodb_filter, query.projection, collection_id
             ) as cursor:
                 async for result in cursor:
-                    code_index = product_codes.index(result["code"])
-                    mongodb_results[code_index] = result
+                    code = result["code"]
+                    code_index = product_codes.index(code)
+                    if mongodb_results[code_index]:
+                        logger.warning(
+                            f"Duplicate product code '{code}' found in MongoDB results"
+                        )
+                    else:
+                        mongodb_results[code_index] = result
 
             # Eliminate any None's from the result. Note this should only happen if there is a mismatch between off-query and MongoDB
             final_result = [result for result in mongodb_results if result]

--- a/query/services/query.py
+++ b/query/services/query.py
@@ -220,7 +220,7 @@ async def find(
             # Nee to convert rows to regular dictionaries to keep Pydantic happy
             return [dict(result) for result in results]
         else:
-            mongodb_filter = {"_id": {"$in": product_codes}}
+            mongodb_filter = {"code": {"$in": product_codes}}
             mongodb_results = [None] * len(product_codes)
             async with find_products(
                 mongodb_filter, query.projection, collection_id

--- a/query/services/query_find_test.py
+++ b/query/services/query_find_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from fastapi import HTTPException, status
@@ -135,6 +135,37 @@ async def test_obsolete(mocked_mongo):
     assert call_args[0][2] == FOOD_OBSOLETE
     assert len(results) == 1
     assert results[0]["code"] == tags.product4["code"]
+
+
+@patch.object(query, "find_products")
+@patch.object(query, "logger")
+async def test_copes_with_duplicate_codes_in_mongodb(logger_mock: Mock, mocked_mongo: Mock):
+    tags = await create_tags_and_scans()
+
+    patch_context_manager(
+        mocked_mongo,
+        mock_cursor(
+            [
+                {"code": tags.product1["code"]},
+                {"code": tags.product1["code"]},
+                {"code": tags.product2["code"]},
+            ]
+        ),
+    )
+    results = await query.find(
+        FindQuery(
+            filter=Filter(amino_acids_tags=tags.amino_value),
+            projection={"code": True, "product_name": True},
+            sort=[("popularity_key", -1)],
+        )
+    )
+    assert mocked_mongo.called
+    call_args = mocked_mongo.call_args
+    assert len(call_args[0][0]["code"]["$in"]) == 2
+    assert len(results) == 2
+    assert results[0]["code"] == tags.product2["code"]
+    assert results[1]["code"] == tags.product1["code"]
+    assert logger_mock.warning.called
 
 
 @patch.object(query, "get_loaded_tags", return_value=[])

--- a/query/services/query_find_test.py
+++ b/query/services/query_find_test.py
@@ -42,7 +42,7 @@ async def test_sorts_by_country_scans(mocked_mongo):
     )
     assert mocked_mongo.called
     call_args = mocked_mongo.call_args
-    assert len(call_args[0][0]["_id"]["$in"]) == 3
+    assert len(call_args[0][0]["code"]["$in"]) == 3
     assert results[0]["code"] == tags.product3["code"]
     assert results[1]["code"] == tags.product2["code"]
     assert results[2]["code"] == tags.product1["code"]
@@ -71,7 +71,7 @@ async def test_sorts_by_world_scans(mocked_mongo):
     )
     assert mocked_mongo.called
     call_args = mocked_mongo.call_args
-    assert len(call_args[0][0]["_id"]["$in"]) == 3
+    assert len(call_args[0][0]["code"]["$in"]) == 3
     assert call_args[0][1] == {"code": True, "product_name": True}
     assert len(results) == 3
     assert results[0]["code"] == tags.product2["code"]
@@ -103,7 +103,7 @@ async def test_limit_and_offset(mocked_mongo):
     )
     assert mocked_mongo.called
     call_args = mocked_mongo.call_args
-    assert len(call_args[0][0]["_id"]["$in"]) == 1
+    assert len(call_args[0][0]["code"]["$in"]) == 1
     assert call_args[0][1] == {"code": True, "product_name": True}
     assert len(results) == 1
     assert results[0]["code"] == tags.product3["code"]
@@ -131,7 +131,7 @@ async def test_obsolete(mocked_mongo):
     )
     assert mocked_mongo.called
     call_args = mocked_mongo.call_args
-    assert len(call_args[0][0]["_id"]["$in"]) == 1
+    assert len(call_args[0][0]["code"]["$in"]) == 1
     assert call_args[0][2] == FOOD_OBSOLETE
     assert len(results) == 1
     assert results[0]["code"] == tags.product4["code"]

--- a/query/tables/product_update.py
+++ b/query/tables/product_update.py
@@ -22,6 +22,11 @@ async def create_table(transaction: Connection):
         "create index product_update_updated_date_index on product_update (updated_date);"
     )
 
+async def migration_add_product_foreign_key(transaction: Connection):
+    await transaction.execute("DELETE FROM product_update WHERE product_id NOT IN (SELECT id FROM product);")
+    await transaction.execute(
+        "ALTER TABLE product_update ADD CONSTRAINT product_update_product_id_fkey FOREIGN KEY (product_id) REFERENCES product(id) ON UPDATE CASCADE ON DELETE CASCADE;"
+    )
 
 async def create_updates_from_events(transaction: Connection, event_ids: List[int]):
     await create_contributors_from_events(transaction, event_ids)


### PR DESCRIPTION
### What
Addresses issues where product codes exist in off-query but not in MongoDB resulting in the number of products on a results page not matching the displayed count

### Fixes bug(s)
- #339

